### PR TITLE
feat(admin): real Lemon Squeezy revenue + purchase-intent funnel tracking

### DIFF
--- a/apps/api/src/admin/admin.controller.ts
+++ b/apps/api/src/admin/admin.controller.ts
@@ -39,6 +39,18 @@ export class AdminController {
     return this.adminService.getDashboardStats();
   }
 
+  @Get('revenue-by-tier')
+  @ApiOperation({ summary: 'Revenue, sales, failed payments and churn per plan' })
+  getRevenueByTier() {
+    return this.adminService.getRevenueByTier();
+  }
+
+  @Get('funnel')
+  @ApiOperation({ summary: 'Purchase-intent funnel: viewed -> clicked -> checkout -> completed' })
+  getFunnel() {
+    return this.adminService.getFunnel();
+  }
+
   // ==================== USERS ====================
 
   @Get('users')

--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -53,14 +53,18 @@ export class AdminService {
       this.db.from('profiles').select('id', { count: 'exact', head: true }).gte('created_at', new Date(Date.now() - 30 * 86400000).toISOString()),
       this.db.from('subscriptions').select('id', { count: 'exact', head: true }).eq('status', 'active'),
       this.db.from('blog_posts').select('id', { count: 'exact', head: true }).eq('status', 'published'),
-      this.db.from('affiliate_sales').select('id', { count: 'exact', head: true }).eq('status', 'confirmed'),
-      this.db.from('affiliate_sales').select('amount').in('status', ['confirmed', 'paid']),
+      this.db.from('ls_webhook_events').select('id', { count: 'exact', head: true }).eq('event_name', 'subscription_created'),
+      // ponytail: summed in JS like the affiliate queries below it. Move to a
+      // Postgres RPC if the payment count ever outgrows a single page.
+      this.db.from('ls_webhook_events').select('amount_cents').eq('event_name', 'subscription_payment_success').eq('status', 'paid'),
       this.db.from('mail_messages').select('id', { count: 'exact', head: true }).eq('status', 'unread'),
       this.db.from('job_applications').select('id', { count: 'exact', head: true }).eq('status', 'pending'),
       this.db.from('affiliate_requests').select('id', { count: 'exact', head: true }).eq('status', 'pending'),
     ]);
 
-    const totalRevenue = revenueRes.data?.reduce((sum, r) => sum + Number(r.amount || 0), 0) ?? 0;
+    // Lemon Squeezy reports money in cents.
+    const totalRevenue =
+      (revenueRes.data?.reduce((sum, r) => sum + Number(r.amount_cents || 0), 0) ?? 0) / 100;
 
     return {
       totalUsers: usersRes.count ?? 0,
@@ -72,6 +76,88 @@ export class AdminService {
       unreadMails: mailsRes.count ?? 0,
       pendingApplications: applicationsRes.count ?? 0,
       pendingAffiliateRequests: affiliateRequestsRes.count ?? 0,
+    };
+  }
+
+  // ==================== REVENUE & FUNNEL ====================
+
+  /**
+   * Revenue, sales, failed payments and churn per plan, from the Lemon Squeezy
+   * webhook audit trail. Revenue counts subscription_payment_success only --
+   * order_created also fires for a subscription's first payment, so counting
+   * both would double every initial purchase.
+   */
+  async getRevenueByTier() {
+    const { data, error } = await this.db
+      .from('ls_revenue_by_tier')
+      .select('*')
+      .order('revenue_cents', { ascending: false });
+
+    if (error) throw new BadRequestException(error.message);
+
+    return (data ?? []).map((r) => ({
+      tier: r.tier as string,
+      revenue: Number(r.revenue_cents ?? 0) / 100,
+      payments: Number(r.payments ?? 0),
+      sales: Number(r.sales ?? 0),
+      failedPayments: Number(r.failed_payments ?? 0),
+      churned: Number(r.churned ?? 0),
+    }));
+  }
+
+  /**
+   * Purchase-intent funnel: viewed -> clicked -> checkout started -> completed.
+   * The first three steps come from our own frontend (Lemon Squeezy only sees
+   * people who already reached its checkout); completions come from the
+   * webhook trail, joined by plan name.
+   */
+  async getFunnel() {
+    const [funnelRes, tiers] = await Promise.all([
+      this.db.from('funnel_summary').select('*'),
+      this.getRevenueByTier(),
+    ]);
+
+    if (funnelRes.error) throw new BadRequestException(funnelRes.error.message);
+
+    const rows = funnelRes.data ?? [];
+    const sessionsFor = (event: string, tier?: string) =>
+      rows
+        .filter((r) => r.event === event && (tier ? r.tier === tier : true))
+        .reduce((sum, r) => sum + Number(r.sessions ?? 0), 0);
+
+    // Tiers people actually interacted with, plus any tier that has sold.
+    const tierNames = Array.from(
+      new Set([
+        ...rows.map((r) => r.tier as string).filter((t) => t && t !== 'all'),
+        ...tiers.map((t) => t.tier),
+      ]),
+    );
+
+    const completedByTier = new Map<string, number>(
+      tiers.map((t) => [t.tier, t.sales]),
+    );
+
+    return {
+      // pricing_viewed carries no tier, so it is the top of the whole funnel.
+      pricingViewed: sessionsFor('pricing_viewed'),
+      planClicked: sessionsFor('plan_clicked'),
+      checkoutStarted: sessionsFor('checkout_started'),
+      completed: tiers.reduce((sum, t) => sum + t.sales, 0),
+      byTier: tierNames
+        .map((tier) => {
+          const clicked = sessionsFor('plan_clicked', tier);
+          const started = sessionsFor('checkout_started', tier);
+          const completed = completedByTier.get(tier) ?? 0;
+          return {
+            tier,
+            clicked,
+            checkoutStarted: started,
+            completed,
+            abandoned: Math.max(started - completed, 0),
+            conversionRate: clicked ? Math.round((completed / clicked) * 1000) / 10 : 0,
+          };
+        })
+        .sort((a, b) => b.clicked - a.clicked),
     };
   }
 

--- a/apps/api/src/billing/billing.controller.ts
+++ b/apps/api/src/billing/billing.controller.ts
@@ -8,6 +8,7 @@ import {
   Query,
   UseGuards,
   UnauthorizedException,
+  BadRequestException,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiQuery, ApiBody } from '@nestjs/swagger';
 import { BillingService } from './billing.service';
@@ -23,6 +24,47 @@ export class BillingController {
   @ApiOperation({ summary: 'List available billing plans (public)' })
   getPlans() {
     return this.billingService.getPlans();
+  }
+
+  @Post('funnel')
+  @ApiOperation({
+    summary: 'Record a purchase-intent funnel event (public, unauthenticated)',
+    description:
+      'Fired from the pricing page. checkout_started is recorded server-side by the checkout endpoint and is not accepted here.',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['event', 'sessionId'],
+      properties: {
+        event: { type: 'string', enum: ['pricing_viewed', 'plan_clicked'] },
+        tier: { type: 'string' },
+        sessionId: { type: 'string' },
+        referrer: { type: 'string' },
+      },
+    },
+  })
+  async trackFunnelEvent(
+    @Body()
+    body: { event?: string; tier?: string; sessionId?: string; referrer?: string },
+  ) {
+    // Unauthenticated endpoint: only ever accept the two client-side steps, so
+    // a caller can't forge conversions or write arbitrary rows.
+    if (
+      body.event !== 'pricing_viewed' &&
+      body.event !== 'plan_clicked'
+    ) {
+      throw new BadRequestException('Unsupported funnel event');
+    }
+    if (!body.sessionId) throw new BadRequestException('sessionId is required');
+
+    await this.billingService.trackFunnelEvent({
+      event: body.event,
+      tier: body.tier,
+      sessionId: body.sessionId,
+      referrer: body.referrer,
+    });
+    return { tracked: true };
   }
 
   @Get('info')

--- a/apps/api/src/billing/billing.service.spec.ts
+++ b/apps/api/src/billing/billing.service.spec.ts
@@ -94,6 +94,101 @@ describe('BillingService', () => {
     });
   });
 
+  describe('recordWebhookEvent', () => {
+    const insertedRow = () => mockInsert.mock.calls[0][0];
+    let mockInsert: jest.Mock;
+
+    beforeEach(() => {
+      mockInsert = jest.fn().mockResolvedValue({ error: null });
+      mockFrom.mockReturnValue({ insert: mockInsert });
+    });
+
+    it('maps a subscription payment to its amount, status and subscription', async () => {
+      await service.recordWebhookEvent('subscription_payment_success', {
+        meta: { event_name: 'subscription_payment_success' },
+        data: {
+          id: 'invoice-1',
+          type: 'subscription-invoices',
+          attributes: {
+            subscription_id: 555,
+            total: 2900,
+            currency: 'USD',
+            status: 'paid',
+            user_email: 'buyer@test.com',
+            created_at: '2026-07-01T00:00:00.000Z',
+          },
+        },
+      });
+
+      expect(mockFrom).toHaveBeenCalledWith('ls_webhook_events');
+      expect(insertedRow()).toMatchObject({
+        event_name: 'subscription_payment_success',
+        ls_id: 'invoice-1',
+        ls_subscription_id: '555',
+        amount_cents: 2900,
+        status: 'paid',
+        customer_email: 'buyer@test.com',
+      });
+    });
+
+    it('uses the subscription id itself when the event is the subscription', async () => {
+      await service.recordWebhookEvent('subscription_created', {
+        meta: { event_name: 'subscription_created' },
+        data: {
+          id: '777',
+          type: 'subscriptions',
+          attributes: { variant_id: 42, status: 'active' },
+        },
+      });
+
+      expect(insertedRow()).toMatchObject({
+        ls_subscription_id: '777',
+        variant_id: '42',
+        amount_cents: 0,
+      });
+    });
+
+    it('swallows duplicate-delivery errors so Lemon Squeezy is not retried', async () => {
+      mockInsert.mockResolvedValue({ error: { code: '23505', message: 'dup' } });
+
+      await expect(
+        service.recordWebhookEvent('subscription_created', {
+          meta: { event_name: 'subscription_created' },
+          data: { id: '777', type: 'subscriptions', attributes: {} },
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('trackFunnelEvent', () => {
+    it('truncates caller-supplied strings and never throws', async () => {
+      const mockInsert = jest.fn().mockResolvedValue({ error: null });
+      mockFrom.mockReturnValue({ insert: mockInsert });
+
+      await service.trackFunnelEvent({
+        event: 'plan_clicked',
+        tier: 'x'.repeat(200),
+        sessionId: 's'.repeat(300),
+        referrer: 'r'.repeat(900),
+      });
+
+      const row = mockInsert.mock.calls[0][0];
+      expect(row.tier).toHaveLength(64);
+      expect(row.session_id).toHaveLength(128);
+      expect(row.referrer).toHaveLength(512);
+    });
+
+    it('does not throw when the insert blows up', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('db down');
+      });
+
+      await expect(
+        service.trackFunnelEvent({ event: 'pricing_viewed', sessionId: 'abc' }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe('getUsageHistory', () => {
     it('should aggregate usage across tables', async () => {
       const mockData = [

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -255,7 +255,50 @@ export class BillingService {
       throw new BadRequestException('Failed to create checkout');
     }
 
+    // Tracked here rather than in the frontend so every entry point into
+    // checkout (billing settings, upgrade promo cards) is counted once.
+    await this.trackFunnelEvent({
+      event: 'checkout_started',
+      tier: plan.name,
+      userId,
+      sessionId: `user:${userId}`,
+    });
+
     return { url: data?.data.attributes.url };
+  }
+
+  // --- Purchase-intent funnel ---
+
+  /**
+   * Record a step of the purchase funnel. Lemon Squeezy only ever sees people
+   * who already reached its checkout, so intent above that has to come from us.
+   * Never throws: analytics must not break a checkout or a page render.
+   */
+  async trackFunnelEvent(input: {
+    event: string;
+    tier?: string | null;
+    userId?: string | null;
+    sessionId: string;
+    referrer?: string | null;
+  }) {
+    const trim = (v: string | null | undefined, max: number) =>
+      v ? v.slice(0, max) : null;
+
+    try {
+      const { error } = await this.supabaseService
+        .getClient()
+        .from('funnel_events')
+        .insert({
+          event: input.event,
+          tier: trim(input.tier, 64),
+          user_id: input.userId ?? null,
+          session_id: input.sessionId.slice(0, 128),
+          referrer: trim(input.referrer, 512),
+        });
+      if (error) this.logger.warn(`Funnel event insert failed: ${error.message}`);
+    } catch (err) {
+      this.logger.warn(`Funnel event insert threw: ${err}`);
+    }
   }
 
   async getCustomerPortalUrl(userId: string) {
@@ -693,6 +736,65 @@ export class BillingService {
     const totalUsed = rows.reduce((sum, r) => sum + (r.credits_consumed ?? 0), 0);
 
     return { usage: result, totalUsed, range };
+  }
+
+  // --- Webhook audit trail ---
+
+  /**
+   * Persist every verified Lemon Squeezy webhook, including ones we don't act
+   * on. This table is the source of truth for admin revenue/sales reporting.
+   * Never throws: a reporting write must not fail the webhook and trigger a
+   * pointless Lemon Squeezy retry of an event we already handled.
+   */
+  async recordWebhookEvent(eventName: string, event: LsWebhookEvent) {
+    const attrs = event.data?.attributes ?? {};
+    const str = (v: unknown) => (v == null ? null : String(v));
+
+    // Invoices carry subscription_id; the subscription_* events are the
+    // subscription itself. Either way this links a payment back to its plan.
+    const lsSubscriptionId =
+      attrs.subscription_id != null
+        ? String(attrs.subscription_id)
+        : event.data?.type === 'subscriptions'
+          ? String(event.data.id)
+          : null;
+
+    const firstItem = attrs.first_order_item as
+      | Record<string, unknown>
+      | undefined;
+
+    const rawOccurredAt = (attrs.updated_at ?? attrs.created_at) as
+      | string
+      | undefined;
+    const occurredAt = rawOccurredAt ? new Date(rawOccurredAt) : new Date();
+
+    try {
+      const { error } = await this.supabaseService
+        .getClient()
+        .from('ls_webhook_events')
+        .insert({
+          event_name: eventName,
+          ls_id: String(event.data?.id ?? ''),
+          ls_subscription_id: lsSubscriptionId,
+          customer_email: str(attrs.user_email),
+          variant_id: str(attrs.variant_id ?? firstItem?.variant_id),
+          amount_cents: Number(attrs.total ?? 0) || 0,
+          currency: str(attrs.currency),
+          status: str(attrs.status),
+          payload: event,
+          occurred_at: (
+            isNaN(occurredAt.getTime()) ? new Date() : occurredAt
+          ).toISOString(),
+        });
+
+      // 23505 = duplicate delivery of an identical payload. Lemon Squeezy
+      // retries, so this is expected and not worth logging as an error.
+      if (error && error.code !== '23505') {
+        this.logger.error(`Webhook event record failed: ${error.message}`);
+      }
+    } catch (err) {
+      this.logger.error(`Webhook event record threw: ${err}`);
+    }
   }
 
   // --- Webhook signature verification ---

--- a/apps/api/src/billing/lemonsqueezy-webhook.controller.ts
+++ b/apps/api/src/billing/lemonsqueezy-webhook.controller.ts
@@ -65,6 +65,11 @@ export class LemonSqueezyWebhookController {
     const eventName = req.headers['x-event-name'] as string;
     const event: LsWebhookEvent = req.body;
 
+    // Record before dispatching so the audit trail captures events we don't act
+    // on (order_created, subscription_payment_failed) and survives a handler
+    // that throws. Never throws itself.
+    await this.billingService.recordWebhookEvent(eventName, event);
+
     try {
       switch (eventName) {
         case 'subscription_created':

--- a/apps/web/app/dashboard/admin/page.tsx
+++ b/apps/web/app/dashboard/admin/page.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import Link from "next/link"
-import { useAdminStats } from "@/hooks/useAdmin"
+import { useAdminStats, useAdminFunnel } from "@/hooks/useAdmin"
+import type { FunnelTierBreakdown } from "@repo/validation"
 import { useSupabase } from "@/components/supabase-provider"
 import { AdminButton } from "@/components/admin/admin-button"
 import {
@@ -19,6 +20,8 @@ import {
   Link2,
   ClipboardList,
   Sparkles,
+  Eye,
+  MousePointerClick,
 } from "lucide-react"
 
 type StatConfig = {
@@ -62,6 +65,75 @@ const QUICK_ACTIONS: Array<{ label: string; description: string; href: string; i
   { label: "Affiliates", description: "Requests, links and sales", href: "/dashboard/admin/affiliates", icon: Link2, gradient: "from-indigo-500 to-purple-500" },
   { label: "Activities", description: "Audit trail across the app", href: "/dashboard/admin/activities", icon: Activity, gradient: "from-amber-500 to-orange-500" },
 ]
+
+/**
+ * Purchase-intent funnel. The first three steps are tracked from our own
+ * frontend; Lemon Squeezy only ever sees people who reached its checkout.
+ */
+function FunnelSection() {
+  const { funnel, loading } = useAdminFunnel()
+
+  if (loading) {
+    return (
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Conversion Funnel</h2>
+        <div className="h-32 rounded-2xl bg-slate-900 border border-slate-800 animate-pulse" />
+      </section>
+    )
+  }
+  if (!funnel) return null
+
+  const steps: StatConfig[] = [
+    { label: "Pricing Viewed", value: funnel.pricingViewed, icon: Eye, gradient: "from-slate-500 to-slate-400", accent: "text-slate-300" },
+    { label: "Plan Clicked", value: funnel.planClicked, icon: MousePointerClick, gradient: "from-blue-500 to-cyan-500", accent: "text-blue-400" },
+    { label: "Checkout Started", value: funnel.checkoutStarted, icon: CreditCard, gradient: "from-purple-500 to-fuchsia-500", accent: "text-purple-400" },
+    { label: "Completed", value: funnel.completed, icon: TrendingUp, gradient: "from-emerald-500 to-teal-500", accent: "text-emerald-400" },
+  ]
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Conversion Funnel</h2>
+        <span className="text-xs text-slate-500">unique sessions</span>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {steps.map((s) => <StatCard key={s.label} {...s} />)}
+      </div>
+
+      {funnel.byTier.length > 0 && (
+        <div className="rounded-2xl border border-slate-800/80 bg-slate-900/60 backdrop-blur overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm min-w-[560px]">
+              <thead>
+                <tr className="border-b border-slate-800 text-xs uppercase tracking-wide text-slate-500">
+                  <th className="text-left font-medium py-3 px-5">Tier</th>
+                  <th className="text-right font-medium py-3 px-5">Clicked</th>
+                  <th className="text-right font-medium py-3 px-5">Checkout</th>
+                  <th className="text-right font-medium py-3 px-5">Completed</th>
+                  <th className="text-right font-medium py-3 px-5">Abandoned</th>
+                  <th className="text-right font-medium py-3 px-5">Conv.</th>
+                </tr>
+              </thead>
+              <tbody>
+                {funnel.byTier.map((t: FunnelTierBreakdown) => (
+                  <tr key={t.tier} className="border-b border-slate-800/60 last:border-0 hover:bg-slate-900">
+                    <td className="py-3 px-5 text-slate-100 font-medium">{t.tier}</td>
+                    <td className="py-3 px-5 text-right text-slate-300 tabular-nums">{t.clicked}</td>
+                    <td className="py-3 px-5 text-right text-slate-300 tabular-nums">{t.checkoutStarted}</td>
+                    <td className="py-3 px-5 text-right text-emerald-400 tabular-nums">{t.completed}</td>
+                    <td className="py-3 px-5 text-right text-amber-400 tabular-nums">{t.abandoned}</td>
+                    <td className="py-3 px-5 text-right text-slate-300 tabular-nums">{t.conversionRate}%</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
 
 export default function AdminDashboardPage() {
   const { stats, loading } = useAdminStats()
@@ -157,6 +229,8 @@ export default function AdminDashboardPage() {
           {revenue.map((s) => <StatCard key={s.label} {...s} />)}
         </div>
       </section>
+
+      <FunnelSection />
 
       <section className="space-y-3">
         <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Needs Attention</h2>

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -14,6 +14,7 @@ import { MButton } from "@repo/ui/moving-border"
 import { ArrowRight, Check, Zap, CreditCard, Shield } from "lucide-react"
 import { useSupabase } from "@/components/supabase-provider"
 import { MARKETING_PLANS, ALL_FEATURES } from "@/lib/pricing-plans"
+import { trackFunnel } from "@/lib/funnel"
 
 export default function PricingPage() {
   const { user } = useSupabase()
@@ -21,6 +22,10 @@ export default function PricingPage() {
   useEffect(() => {
     const lenis = new Lenis({ autoRaf: true })
     return () => lenis.destroy()
+  }, [])
+
+  useEffect(() => {
+    trackFunnel("pricing_viewed")
   }, [])
 
   const billingHref = (planId: string) =>

--- a/apps/web/components/landingPage/PricingSection.tsx
+++ b/apps/web/components/landingPage/PricingSection.tsx
@@ -9,6 +9,7 @@ import { motion } from "motion/react"
 import { Check } from "lucide-react"
 import { useSupabase } from "../supabase-provider"
 import { MARKETING_PLANS, type MarketingPlan } from "@/lib/pricing-plans"
+import { trackFunnel } from "@/lib/funnel"
 
 const containerVariants = {
     hidden: { opacity: 0 },
@@ -187,7 +188,9 @@ function PlanCard({ plan, annual, href }: { plan: MarketingPlan; annual: boolean
                     )}
                     variant={isPopular ? "default" : "outline"}
                 >
-                    <Link href={href}>{isFree ? "Start Free" : "Get Started"}</Link>
+                    <Link href={href} onClick={() => trackFunnel("plan_clicked", plan.name)}>
+                        {isFree ? "Start Free" : "Get Started"}
+                    </Link>
                 </Button>
             </WobbleCard>
         </motion.div>

--- a/apps/web/hooks/useAdmin.ts
+++ b/apps/web/hooks/useAdmin.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { api } from '@/lib/api-client';
 import type {
   AdminDashboardStats,
+  AdminFunnel,
   BlogPost,
   MailMessage,
   ActivityFeedItem,
@@ -34,6 +35,26 @@ export function useAdminStats() {
 
   useEffect(() => { fetchStats(); }, [fetchStats]);
   return { stats, loading, refresh: fetchStats };
+}
+
+export function useAdminFunnel() {
+  const [funnel, setFunnel] = useState<AdminFunnel | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchFunnel = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await api.get<AdminFunnel>('/api/v1/admin/funnel', AUTH);
+      setFunnel(data);
+    } catch (err) {
+      console.error('Failed to fetch funnel:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchFunnel(); }, [fetchFunnel]);
+  return { funnel, loading, refresh: fetchFunnel };
 }
 
 export function useAdminUsers(page = 1, search?: string, role?: string) {

--- a/apps/web/lib/funnel.ts
+++ b/apps/web/lib/funnel.ts
@@ -1,0 +1,44 @@
+/**
+ * Purchase-intent tracking for the pricing page.
+ *
+ * Lemon Squeezy only ever sees people who already reached its checkout, so the
+ * steps above that have to come from us. `checkout_started` is recorded
+ * server-side when the checkout session is created, so it is not sent here.
+ */
+
+const SESSION_KEY = "caf_session_id"
+
+/** Anonymous, per-tab id so the funnel can count people rather than clicks. */
+function getSessionId(): string {
+  try {
+    const existing = sessionStorage.getItem(SESSION_KEY)
+    if (existing) return existing
+    const id = crypto.randomUUID()
+    sessionStorage.setItem(SESSION_KEY, id)
+    return id
+  } catch {
+    // Private mode / storage disabled: still track, just as a one-off session.
+    return "no-storage"
+  }
+}
+
+export function trackFunnel(event: "pricing_viewed" | "plan_clicked", tier?: string) {
+  if (typeof window === "undefined") return
+
+  const backend = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:8000"
+
+  // keepalive so a plan_clicked fired as the user navigates away still lands.
+  fetch(`${backend}/api/v1/billing/funnel`, {
+    method: "POST",
+    keepalive: true,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      event,
+      tier,
+      sessionId: getSessionId(),
+      referrer: document.referrer || undefined,
+    }),
+  }).catch(() => {
+    // Analytics must never break the page.
+  })
+}

--- a/packages/supabase/migrations/20260722000000_revenue_funnel_tracking.sql
+++ b/packages/supabase/migrations/20260722000000_revenue_funnel_tracking.sql
@@ -1,0 +1,78 @@
+-- Revenue + purchase-intent funnel tracking.
+--
+-- The admin "Total Revenue"/"Total Sales" cards used to read affiliate_sales,
+-- which only ever holds affiliate commissions -- hence $0.00 / 0 despite live
+-- subscriptions. Real money now comes from ls_webhook_events, the audit trail
+-- of every Lemon Squeezy webhook we accept.
+
+create table if not exists "public"."ls_webhook_events" (
+  "id" uuid primary key default gen_random_uuid(),
+  "event_name" text not null,
+  "ls_id" text not null,              -- Lemon Squeezy data.id (order / subscription / invoice)
+  "ls_subscription_id" text,          -- links payments back to subscriptions -> plans
+  "customer_email" text,
+  "variant_id" text,
+  "amount_cents" integer not null default 0,
+  "currency" text,
+  "status" text,
+  "payload" jsonb not null,
+  "occurred_at" timestamptz not null,
+  "created_at" timestamptz not null default now(),
+  -- Lemon Squeezy retries failed deliveries and the event may be registered to
+  -- more than one endpoint. A retry replays an identical payload, so its
+  -- occurred_at matches; a genuine later update carries a newer one.
+  unique ("event_name", "ls_id", "occurred_at")
+);
+
+create index if not exists "ls_webhook_events_event_name_idx" on "public"."ls_webhook_events" ("event_name");
+create index if not exists "ls_webhook_events_subscription_idx" on "public"."ls_webhook_events" ("ls_subscription_id");
+create index if not exists "ls_webhook_events_created_at_idx" on "public"."ls_webhook_events" ("created_at" desc);
+
+-- Purchase intent, tracked from our own frontend: Lemon Squeezy only ever sees
+-- the people who already reached its checkout.
+create table if not exists "public"."funnel_events" (
+  "id" uuid primary key default gen_random_uuid(),
+  "event" text not null check ("event" in ('pricing_viewed', 'plan_clicked', 'checkout_started')),
+  "tier" text,
+  "user_id" uuid,
+  "session_id" text not null,
+  "referrer" text,
+  "created_at" timestamptz not null default now()
+);
+
+create index if not exists "funnel_events_event_idx" on "public"."funnel_events" ("event");
+create index if not exists "funnel_events_created_at_idx" on "public"."funnel_events" ("created_at" desc);
+
+-- Written and read only by the API's service-role client: RLS on, no policies.
+alter table "public"."ls_webhook_events" enable row level security;
+alter table "public"."funnel_events" enable row level security;
+
+-- Revenue is summed from subscription_payment_success only. Lemon Squeezy also
+-- fires order_created for the first payment of a subscription, so counting both
+-- would double-bill every initial purchase. order_created is still stored for
+-- the audit trail.
+create or replace view "public"."ls_revenue_by_tier" with (security_invoker = on) as
+select
+  p.name as tier,
+  coalesce(sum(e.amount_cents) filter (
+    where e.event_name = 'subscription_payment_success' and e.status = 'paid'
+  ), 0)::bigint as revenue_cents,
+  count(*) filter (
+    where e.event_name = 'subscription_payment_success' and e.status = 'paid'
+  )::bigint as payments,
+  count(*) filter (where e.event_name = 'subscription_created')::bigint as sales,
+  count(*) filter (where e.event_name = 'subscription_payment_failed')::bigint as failed_payments,
+  count(*) filter (where e.event_name in ('subscription_cancelled', 'subscription_expired'))::bigint as churned
+from "public"."ls_webhook_events" e
+join "public"."subscriptions" s on s.ls_subscription_id = e.ls_subscription_id
+join "public"."plans" p on p.id = s.plan_id
+group by p.name;
+
+create or replace view "public"."funnel_summary" with (security_invoker = on) as
+select
+  event,
+  coalesce(tier, 'all') as tier,
+  count(*)::bigint as events,
+  count(distinct session_id)::bigint as sessions
+from "public"."funnel_events"
+group by 1, 2;

--- a/packages/validations/src/types/index.ts
+++ b/packages/validations/src/types/index.ts
@@ -24,6 +24,33 @@ export interface AdminDashboardStats {
   pendingAffiliateRequests: number
 }
 
+export interface RevenueByTier {
+  tier: string
+  revenue: number
+  payments: number
+  sales: number
+  failedPayments: number
+  churned: number
+}
+
+export interface FunnelTierBreakdown {
+  tier: string
+  clicked: number
+  checkoutStarted: number
+  completed: number
+  abandoned: number
+  /** Completed / clicked, as a percentage rounded to one decimal. */
+  conversionRate: number
+}
+
+export interface AdminFunnel {
+  pricingViewed: number
+  planClicked: number
+  checkoutStarted: number
+  completed: number
+  byTier: FunnelTierBreakdown[]
+}
+
 export interface BlogPost {
   id: string
   author_id: string


### PR DESCRIPTION
## Why

The admin dashboard showed **$0.00 revenue and 0 sales despite 41 active subscriptions**. Root cause: both cards read `affiliate_sales`, which only ever holds affiliate commissions — and no Lemon Squeezy payment was recorded anywhere in the database.

This wires up real revenue, and adds the purchase-intent funnel that Lemon Squeezy structurally cannot give us (it only sees people who already reached its checkout).

## Part 1 — Revenue from Lemon Squeezy webhooks

The webhook endpoint and signature verification already existed; what was missing was persistence.

- New `ls_webhook_events` table: full audit trail of every **verified** webhook, recorded *before* dispatch — so it also captures events we don't act on (`order_created`, `subscription_payment_failed`) and survives a throwing handler.
- Total Revenue / Total Sales now come from that trail. Revenue counts `subscription_payment_success` only: Lemon Squeezy *also* fires `order_created` for a subscription's first payment, so counting both would double every initial purchase.
- New `GET /admin/revenue-by-tier` — revenue, sales, failed payments and churn per plan.

Recording never throws: a reporting write must not fail the webhook and trigger a pointless Lemon Squeezy retry of an event we already handled. Duplicate deliveries are deduped by `(event_name, ls_id, occurred_at)` — a retry replays an identical payload, a genuine later update carries a newer timestamp.

## Part 2 — Purchase-intent funnel

- `pricing_viewed` and `plan_clicked` fire from the pricing page, with `keepalive` so a click that navigates away still lands. Sessions are anonymous and per-tab, so the funnel counts people rather than clicks.
- `checkout_started` is recorded **server-side** in `createCheckoutSession`, so every entry point into checkout (billing settings, upgrade promo cards) is counted without touching each caller.
- New `GET /admin/funnel` joins intent against the webhook trail by plan name to get completions and abandonment per tier.
- New **Conversion Funnel** section on the dashboard: four step cards in the existing style, plus a per-tier drop-off table.

The public ingest endpoint accepts only the two client-side steps, so a caller can't forge conversions, and caller-supplied strings are length-capped.

## Notes

- **Env config is already complete** — `LEMONSQUEEZY_API_KEY`, `LEMONSQUEEZY_STORE_ID` and `LEMONSQUEEZY_WEBHOOK_SECRET` are all in `.env.example` and read by the API. Nothing to add.
- **No new dependency and no BullMQ job.** Aggregation is two indexed queries and two SQL views, computed on request. A scheduled rollup is worth adding when the payment count outgrows a single page — flagged with a `ponytail:` comment at the spot that would change.
- Marketing plan names already match the DB `plans.name` values (Starter/Creator/Pro/Business/Scale), so the tier join works without a mapping table.
- **Backfill:** revenue starts accumulating from deploy. Existing subscriptions predate the trail, so the cards will under-report until each renews. Historical data can be backfilled from the Lemon Squeezy API if you want it — say the word and I'll add a one-off script.

## Testing

`billing.service.spec.ts` covers the money path: webhook→row mapping for payments and subscriptions, duplicate-delivery suppression, and the funnel input caps. 11 tests pass; both apps typecheck clean.
