### PR TITLE
fix(credits): carry referral and purchase bonuses across plan resets

### DIFF
--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -191,15 +191,24 @@ export class AdminService {
       .single();
     if (subErr) throw new BadRequestException(subErr.message);
 
+    // Grant the plan allowance on top of any reset-protected bonus credits the
+    // user has earned (referrals, purchase bonuses) — see migration 20260723000000.
+    const { data: current } = await this.db
+      .from('profiles')
+      .select('bonus_credits')
+      .eq('user_id', userId)
+      .maybeSingle();
+    const bonus = current?.bonus_credits ?? 0;
+
     const { data: profile, error: credErr } = await this.db
       .from('profiles')
-      .update({ credits: plan.credits_monthly })
+      .update({ credits: plan.credits_monthly + bonus })
       .eq('user_id', userId)
       .select()
       .single();
     if (credErr) throw new BadRequestException(credErr.message);
 
-    return { success: true, credits: plan.credits_monthly, subscription: newSub, profile };
+    return { success: true, credits: plan.credits_monthly + bonus, subscription: newSub, profile };
   }
 
   // Feature tables that record per-user credit usage — same set billing uses for

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -325,6 +325,39 @@ export class BillingService {
     return { success: true };
   }
 
+  /**
+   * Set a user's balance to `allowance` while carrying their reset-protected
+   * bonus credits (referral rewards, purchase bonuses) across the reset.
+   * Mirrors the SQL crons — see migration 20260723000000.
+   *
+   * extraBonus grants a NEW bonus in the same write (used at purchase time).
+   */
+  private async applyAllowance(
+    userId: string,
+    allowance: number,
+    supabase: ReturnType<typeof this.supabaseService.getClient>,
+    extraBonus = 0,
+  ) {
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('bonus_credits')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    const bonus = (profile?.bonus_credits ?? 0) + extraBonus;
+
+    const { error } = await supabase
+      .from('profiles')
+      .update({ credits: allowance + bonus, bonus_credits: bonus })
+      .eq('user_id', userId);
+
+    if (error) {
+      this.logger.error(`Failed to reset credits for ${userId}: ${JSON.stringify(error)}`);
+    } else {
+      this.logger.log(`Reset credits to ${allowance} (+${bonus} bonus) for ${userId}`);
+    }
+  }
+
   private async createFreePlanSubscription(userId: string) {
     const supabase = this.supabaseService.getClient();
     const starter = await this.getStarterPlan();
@@ -344,17 +377,8 @@ export class BillingService {
       current_period_end: null,
     });
 
-    // Downgrade the credit balance to the free plan allowance.
-    const { error } = await supabase
-      .from('profiles')
-      .update({ credits: starter.credits_monthly })
-      .eq('user_id', userId);
-
-    if (error) {
-      this.logger.error(`Failed to reset credits for ${userId}: ${JSON.stringify(error)}`);
-    } else {
-      this.logger.log(`Reset credits to ${starter.credits_monthly} (free plan) for ${userId}`);
-    }
+    // Downgrade the credit balance to the free plan allowance, keeping bonuses.
+    await this.applyAllowance(userId, starter.credits_monthly, supabase);
   }
 
   /**
@@ -370,16 +394,7 @@ export class BillingService {
       this.logger.error(`Cannot reset credits for ${userId}: no free plan`);
       return;
     }
-    const { error } = await supabase
-      .from('profiles')
-      .update({ credits: starter.credits_monthly })
-      .eq('user_id', userId);
-
-    if (error) {
-      this.logger.error(`Failed to reset credits for ${userId}: ${JSON.stringify(error)}`);
-    } else {
-      this.logger.log(`Reset credits to ${starter.credits_monthly} (free plan) for ${userId}`);
-    }
+    await this.applyAllowance(userId, starter.credits_monthly, supabase);
   }
 
   /**
@@ -508,10 +523,8 @@ export class BillingService {
         supabase,
       );
 
-      await supabase
-        .from('profiles')
-        .update({ credits: plan.credits_monthly + referralBonus })
-        .eq('user_id', userId);
+      // referralBonus is tagged as protected so the next renewal carries it.
+      await this.applyAllowance(userId, plan.credits_monthly, supabase, referralBonus);
     }
 
     const affiliateCode = event.meta.custom_data?.affiliate_code;
@@ -608,10 +621,7 @@ export class BillingService {
       .single();
 
     if (plan) {
-      await supabase
-        .from('profiles')
-        .update({ credits: plan.credits_monthly })
-        .eq('user_id', sub.user_id);
+      await this.applyAllowance(sub.user_id, plan.credits_monthly, supabase);
 
       await supabase
         .from('subscriptions')

--- a/packages/supabase/migrations/20260723000000_bonus_credits_survive_reset.sql
+++ b/packages/supabase/migrations/20260723000000_bonus_credits_survive_reset.sql
@@ -1,0 +1,188 @@
+-- =====================================================================
+-- Bonus credits survive the monthly/annual reset
+-- ---------------------------------------------------------------------
+-- Problem: every reset path overwrote profiles.credits with the plan's
+-- allowance, so referral rewards and purchase bonuses were silently wiped
+-- at the next renewal (or the daily refresh_annual_credits cron).
+--
+-- Model: profiles.credits stays the ONE spendable balance — every reader
+-- and every deduction site keeps working untouched. profiles.bonus_credits
+-- is a tag on that balance: "this much of it came from a bonus and is
+-- reset-protected". Two rules keep it honest:
+--
+--   spend  -> credits -= n, then bonus_credits = LEAST(bonus_credits, credits)
+--             Plan credits drain first; bonus only shrinks once the balance
+--             has fallen to it. So an unspent bonus survives the month.
+--   reset  -> credits = plan_allowance + bonus_credits  (bonus untouched)
+--
+-- Invariant: 0 <= bonus_credits <= credits, always.
+--
+-- NOTE: bonus_credits starts at 0 for everyone. profiles.referral_credits
+-- is a LIFETIME earned counter (never decremented), so backfilling from it
+-- would re-grant credits users already spent. Bonuses accrue from here on.
+-- =====================================================================
+
+-- 1. The protected-balance tag ---------------------------------------------
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS bonus_credits INTEGER NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.profiles.bonus_credits IS
+  'Portion of profiles.credits that came from referrals/bonuses and is carried '
+  'across plan resets. Always <= credits. Spent last (see update_user_credits).';
+
+-- 2. Spend: drain plan credits first, clamp the bonus tag -------------------
+-- Same signature and same insufficient-balance behaviour as before, so the
+-- six worker processors and the API callers need no changes.
+
+CREATE OR REPLACE FUNCTION public.update_user_credits(user_uuid uuid, credit_change integer)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+  IF credit_change < 0 THEN
+    -- Deduction: ensure sufficient balance.
+    -- On the RHS `credits` is the pre-update value, so `credits + credit_change`
+    -- is the new balance. Clamping bonus to it means the bonus is only eaten
+    -- once plan credits are exhausted.
+    UPDATE profiles
+    SET credits = credits + credit_change,
+        bonus_credits = LEAST(COALESCE(bonus_credits, 0), credits + credit_change),
+        updated_at = NOW()
+    WHERE user_id = user_uuid
+      AND credits + credit_change >= 0;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Insufficient credits' USING ERRCODE = 'P0001';
+    END IF;
+  ELSE
+    -- Addition: always allowed. Plain top-up — callers that mean "this is a
+    -- BONUS" bump bonus_credits themselves (see award_referral_credits).
+    UPDATE profiles
+    SET credits = credits + credit_change,
+        updated_at = NOW()
+    WHERE user_id = user_uuid;
+  END IF;
+END;
+$function$;
+
+-- 3. Referral reward is a bonus -> tag it as protected ----------------------
+-- Identical to 20260619000100 except bonus_credits also moves.
+
+CREATE OR REPLACE FUNCTION public.award_referral_credits()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  credits_to_award INTEGER := 1000;
+  referrer_profile_id UUID;
+BEGIN
+  IF NEW.status = 'completed' AND (OLD.status IS DISTINCT FROM 'completed') THEN
+    referrer_profile_id := NEW.referrer_id;
+
+    UPDATE public.profiles
+       SET credits          = COALESCE(credits, 0) + credits_to_award,
+           bonus_credits    = COALESCE(bonus_credits, 0) + credits_to_award,
+           referral_credits = COALESCE(referral_credits, 0) + credits_to_award,
+           total_referrals  = COALESCE(total_referrals, 0) + 1,
+           updated_at       = NOW()
+     WHERE id = referrer_profile_id;
+
+    IF NEW.credits_awarded IS NULL OR NEW.credits_awarded = 0 THEN
+      NEW.credits_awarded := credits_to_award;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- 4. Annual refresh cron: allowance + carried bonus -------------------------
+
+CREATE OR REPLACE FUNCTION public.refresh_annual_credits()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  rec RECORD;
+BEGIN
+  FOR rec IN
+    SELECT s.id   AS sub_id,
+           s.user_id,
+           p.credits_monthly
+      FROM public.subscriptions s
+      JOIN public.plans p ON p.id = s.plan_id
+     WHERE s.billing_interval = 'annual'
+       AND s.status IN ('active', 'on_trial', 'past_due')
+       AND s.credits_last_refreshed_at < now() - interval '30 days'
+  LOOP
+    UPDATE public.profiles
+       SET credits = rec.credits_monthly + COALESCE(bonus_credits, 0)
+     WHERE user_id = rec.user_id;
+
+    UPDATE public.subscriptions
+       SET credits_last_refreshed_at = now()
+     WHERE id = rec.sub_id;
+
+    RAISE LOG 'Refreshed % credits (+ carried bonus) for user % (sub %)',
+              rec.credits_monthly, rec.user_id, rec.sub_id;
+  END LOOP;
+END;
+$$;
+
+-- 5. Expiry downgrade cron: Starter allowance + carried bonus ---------------
+-- A bonus was earned, not rented — losing the plan must not burn it.
+
+CREATE OR REPLACE FUNCTION public.downgrade_expired_subscriptions()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  starter RECORD;
+  rec     RECORD;
+BEGIN
+  SELECT id, credits_monthly INTO starter
+    FROM public.plans
+   WHERE price_monthly = 0
+   ORDER BY credits_monthly DESC
+   LIMIT 1;
+
+  IF starter.id IS NULL THEN
+    RAISE LOG 'downgrade_expired_subscriptions: no free/Starter plan found, skipping';
+    RETURN;
+  END IF;
+
+  FOR rec IN
+    SELECT s.id AS sub_id, s.user_id
+      FROM public.subscriptions s
+     WHERE s.ls_subscription_id IS NULL          -- admin-granted only
+       AND s.status = 'active'
+       AND s.plan_id <> starter.id
+       AND s.current_period_end IS NOT NULL
+       AND s.current_period_end < now()
+  LOOP
+    UPDATE public.subscriptions
+       SET status = 'canceled'
+     WHERE id = rec.sub_id;
+
+    INSERT INTO public.subscriptions
+      (user_id, plan_id, status, billing_interval,
+       credits_last_refreshed_at, current_period_start, current_period_end)
+    VALUES
+      (rec.user_id, starter.id, 'active', 'monthly',
+       now(), now(), NULL);
+
+    UPDATE public.profiles
+       SET credits = starter.credits_monthly + COALESCE(bonus_credits, 0)
+     WHERE user_id = rec.user_id;
+
+    RAISE LOG 'Downgraded user % to Starter (expired sub %)', rec.user_id, rec.sub_id;
+  END LOOP;
+END;
+$$;

--- a/packages/supabase/scripts/test-bonus-credits.sql
+++ b/packages/supabase/scripts/test-bonus-credits.sql
@@ -1,0 +1,59 @@
+-- Self-check for the bonus-credit carry-over (migration 20260723000000).
+-- Runs inside a transaction and ROLLBACKs — safe against a dev database.
+--
+--   psql "$SUPABASE_DB_URL" -f packages/supabase/scripts/test-bonus-credits.sql
+--
+-- Passes silently. Any broken rule raises an assertion failure naming the case.
+
+BEGIN;
+
+DO $$
+DECLARE
+  uid       UUID := gen_random_uuid();
+  balance   INTEGER;
+  bonus     INTEGER;
+  allowance INTEGER := 8000;   -- Pro
+BEGIN
+  INSERT INTO auth.users (id, email) VALUES (uid, 'bonus-test@example.invalid');
+  INSERT INTO public.profiles (id, user_id, credits, bonus_credits)
+  VALUES (uid, uid, allowance, 0);
+
+  -- A 1,000-credit referral bonus lands on top of the plan allowance.
+  UPDATE public.profiles
+     SET credits = credits + 1000, bonus_credits = bonus_credits + 1000
+   WHERE user_id = uid;
+
+  -- Spend 6,000: plan credits absorb all of it, the bonus is untouched.
+  PERFORM public.update_user_credits(uid, -6000);
+  SELECT credits, bonus_credits INTO balance, bonus FROM public.profiles WHERE user_id = uid;
+  ASSERT balance = 3000, format('spend: expected 3000 credits, got %s', balance);
+  ASSERT bonus = 1000,  format('spend: bonus must survive, got %s', bonus);
+
+  -- The reset (renewal / annual cron / downgrade) carries the bonus over.
+  UPDATE public.profiles
+     SET credits = allowance + COALESCE(bonus_credits, 0)
+   WHERE user_id = uid;
+  SELECT credits, bonus_credits INTO balance, bonus FROM public.profiles WHERE user_id = uid;
+  ASSERT balance = 9000, format('reset: expected 8000+1000, got %s', balance);
+  ASSERT bonus = 1000,  format('reset: bonus must persist, got %s', bonus);
+
+  -- Spend past the plan allowance: only now does the bonus get eaten.
+  PERFORM public.update_user_credits(uid, -8500);
+  SELECT credits, bonus_credits INTO balance, bonus FROM public.profiles WHERE user_id = uid;
+  ASSERT balance = 500, format('overdraw: expected 500, got %s', balance);
+  ASSERT bonus = 500,  format('overdraw: bonus clamps to balance, got %s', bonus);
+
+  -- The insufficient-balance guard still fires, and changes nothing.
+  BEGIN
+    PERFORM public.update_user_credits(uid, -10000);
+    RAISE EXCEPTION 'guard: overspend should have been rejected';
+  EXCEPTION WHEN SQLSTATE 'P0001' THEN
+    NULL;
+  END;
+  SELECT credits, bonus_credits INTO balance, bonus FROM public.profiles WHERE user_id = uid;
+  ASSERT balance = 500 AND bonus = 500, 'guard: rejected spend must not mutate the row';
+
+  RAISE NOTICE 'bonus-credit carry-over: all cases passed';
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## Why

Every reset path overwrote `profiles.credits` with the plan's allowance, so referral rewards and purchase bonuses were **silently wiped** at the next renewal — or by the daily `refresh_annual_credits` cron, whichever came first. A bonus was earned, not rented.

## Model

`profiles.credits` stays the one spendable balance, so every reader and every deduction site keeps working untouched. `profiles.bonus_credits` is a tag on that balance — "this much of it is reset-protected" — under a single invariant:

```
0 <= bonus_credits <= credits
```

Two rules keep it honest:

| | |
|---|---|
| **spend** | `credits -= n`, then `bonus_credits = LEAST(bonus_credits, credits)` |
| **reset** | `credits = allowance + bonus_credits` (bonus untouched) |

Plan credits drain first: the bonus tag only shrinks once the balance has fallen to it. So an unspent bonus survives the month, and a user who burns through everything doesn't keep a phantom protected balance.

## Coverage

All five reset paths carry the bonus:

- `refresh_annual_credits` — annual cron
- `downgrade_expired_subscriptions` — expiry cron
- `createFreePlanSubscription` — free-plan downgrade
- `resetCreditsToFreePlan` — credit reset
- `handleSubscriptionPaymentSuccess` — renewal payment

The three TypeScript paths were collapsed into one `applyAllowance()` helper rather than repeating the read-bonus-then-write dance at each site, and `handleSubscriptionCreated` now routes its referral bonus through the same helper so the grant is tagged as protected at purchase time.

`update_user_credits` keeps its exact signature and insufficient-balance behaviour, so the six worker processors and every API caller need no changes.

## Backfill: deliberately none

`bonus_credits` starts at 0 for everyone. `profiles.referral_credits` is a **lifetime earned** counter that is never decremented, so backfilling from it would re-grant credits users have already spent. Bonuses accrue from here on.

## Testing

`packages/supabase/scripts/test-bonus-credits.sql` asserts the rules against a dev database, inside a transaction that rolls back:

```bash
psql "$SUPABASE_DB_URL" -f packages/supabase/scripts/test-bonus-credits.sql
```

It covers the bonus surviving a partial spend, the reset carrying it, and the bonus being consumed only once the plan allowance is exhausted. API typechecks clean.

## One note for review

`applyAllowance()` reads `bonus_credits` and then writes in a separate statement. A credit spend landing between the two would be overwritten by the reset. The SQL crons do it atomically in a single `UPDATE`; the TypeScript paths don't. The window is small and these run on renewal/downgrade rather than in hot paths, but it's a real race — worth folding into a single statement or an RPC if it ever bites.
