### PR TITLE
feat(train-ai): show a clear out-of-credits dialog when training fails

### DIFF
--- a/apps/web/app/dashboard/train/page.tsx
+++ b/apps/web/app/dashboard/train/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { SuccessDialog } from "@/components/success-dialog";
+import { OutOfCreditsDialog } from "@/components/dashboard/common/OutOfCreditsDialog";
 import * as motion from "motion/react-m";
 import { PenTool, Search, Volume2, ImageIcon, Subtitles, BookOpen } from "lucide-react";
 import { useAITraining } from "@/hooks/useAITraining";
@@ -28,6 +29,8 @@ export default function TrainAIPage() {
     showModal,
     selectedVideoIds,
     lastCreditsConsumed,
+    outOfCreditsMessage,
+    dismissOutOfCredits,
     setShowModal,
     handleToggleVideo,
     handleStartTraining,
@@ -78,6 +81,12 @@ export default function TrainAIPage() {
         title="Model Training Complete!"
         description="Your AI model has been trained on your unique style. Enjoy the personalized experience."
         nextSteps={nextSteps}
+      />
+
+      <OutOfCreditsDialog
+        open={outOfCreditsMessage !== null}
+        onOpenChange={dismissOutOfCredits}
+        description={outOfCreditsMessage ?? ""}
       />
     </div>
   );

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -44,6 +44,16 @@ const organizationJsonLd = {
   sameAs: [`https://twitter.com/${siteConfig.twitterHandle.replace("@", "")}`],
 }
 
+// Tells Google which name to render as the site title in search results.
+const webSiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: siteConfig.name,
+  alternateName: ["Creator AI App", "Script AI"],
+  url: siteConfig.url,
+  sameAs: ["https://trycreatorai.com/"],
+}
+
 const webAppJsonLd = {
   "@context": "https://schema.org",
   "@type": "WebApplication",
@@ -70,6 +80,7 @@ export default function RootLayout({
         {/* Client boundary is confined to this one null-rendering component. */}
         <WebVitals />
         <JsonLd data={organizationJsonLd} />
+        <JsonLd data={webSiteJsonLd} />
         <JsonLd data={webAppJsonLd} />
         <ThemeProvider
           attribute="class"

--- a/apps/web/components/dashboard/common/OutOfCreditsDialog.tsx
+++ b/apps/web/components/dashboard/common/OutOfCreditsDialog.tsx
@@ -10,7 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@repo/ui/dialog"
-import { CreditCard, ArrowRight } from "lucide-react"
+import { CreditCard, ArrowRight, Gift } from "lucide-react"
 
 interface OutOfCreditsDialogProps {
   open: boolean
@@ -36,8 +36,13 @@ export function OutOfCreditsDialog({ open, onOpenChange, description }: OutOfCre
         </DialogHeader>
 
         <DialogFooter className="mt-2 flex-col-reverse gap-2 sm:flex-row sm:justify-center">
-          <Button variant="outline" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
-            Maybe later
+          {/* Referral first, so the free route is on the table before the paid one.
+              The dialog's own X still handles dismissing. */}
+          <Button asChild variant="outline" className="w-full sm:w-auto">
+            <Link href="/dashboard/referrals" onClick={() => onOpenChange(false)}>
+              <Gift className="mr-1.5 h-4 w-4" />
+              Earn more credits
+            </Link>
           </Button>
           <Button
             asChild

--- a/apps/web/components/dashboard/common/OutOfCreditsDialog.tsx
+++ b/apps/web/components/dashboard/common/OutOfCreditsDialog.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import Link from "next/link"
+import { Button } from "@repo/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/dialog"
+import { CreditCard, ArrowRight } from "lucide-react"
+
+interface OutOfCreditsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** The message from the job that failed, e.g. how many credits the run needed. */
+  description: string
+}
+
+export function OutOfCreditsDialog({ open, onOpenChange, description }: OutOfCreditsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader className="text-center items-center gap-3">
+          <div className="flex items-center justify-center w-14 h-14 rounded-full bg-amber-100 dark:bg-amber-900/30">
+            <CreditCard className="h-7 w-7 text-amber-600 dark:text-amber-400" />
+          </div>
+          <DialogTitle className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+            You&apos;re out of credits
+          </DialogTitle>
+          <DialogDescription className="text-slate-600 dark:text-slate-400">
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter className="mt-2 flex-col-reverse gap-2 sm:flex-row sm:justify-center">
+          <Button variant="outline" className="w-full sm:w-auto" onClick={() => onOpenChange(false)}>
+            Maybe later
+          </Button>
+          <Button
+            asChild
+            className="w-full sm:w-auto bg-purple-600 hover:bg-purple-700 text-white"
+          >
+            <Link href="/dashboard/settings?tab=billing" onClick={() => onOpenChange(false)}>
+              Get more credits
+              <ArrowRight className="ml-1.5 h-4 w-4" />
+            </Link>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/components/landingPage/PricingSection.tsx
+++ b/apps/web/components/landingPage/PricingSection.tsx
@@ -192,7 +192,14 @@ function PlanCard({ plan, annual, href }: { plan: MarketingPlan; annual: boolean
                     )}
                     variant={isPopular ? "default" : "outline"}
                 >
-                    <Link href={href} onClick={() => trackFunnel("plan_clicked", plan.name)}>
+                    {/* Every card renders the same "Get Started" text but points at a
+                        different plan, so the visible label alone can't tell two links
+                        apart. The plan name goes in the accessible name instead. */}
+                    <Link
+                        href={href}
+                        aria-label={isFree ? "Start free on the Free plan" : `Get started with the ${plan.name} plan`}
+                        onClick={() => trackFunnel("plan_clicked", plan.name)}
+                    >
                         {isFree ? "Start Free" : "Get Started"}
                     </Link>
                 </Button>

--- a/apps/web/hooks/useAITraining.ts
+++ b/apps/web/hooks/useAITraining.ts
@@ -31,6 +31,7 @@ export function useAITraining() {
   const [jobId, setJobId] = useState<string | null>(null)
   const [isTraining, setIsTraining] = useState(false)
   const [lastCreditsConsumed, setLastCreditsConsumed] = useState<number | null>(null)
+  const [outOfCreditsMessage, setOutOfCreditsMessage] = useState<string | null>(null)
 
   useEffect(() => {
     if (!user?.id || !profile?.ai_trained || !supabase) return
@@ -59,6 +60,12 @@ export function useAITraining() {
         const parsed = JSON.parse(error)
         errorMessage = parsed.error?.message || parsed.message || error
       } catch { }
+      // Running out of credits is the one failure the user can act on, so it gets
+      // a dialog with a route to billing instead of a toast they can miss.
+      if (errorMessage.toLowerCase().startsWith("insufficient credits")) {
+        setOutOfCreditsMessage(errorMessage.replace(/^insufficient credits\.\s*/i, ""))
+        return
+      }
       toast.error("Training Failed", { description: errorMessage })
     },
     onFinished: () => {
@@ -148,6 +155,8 @@ export function useAITraining() {
     selectedVideos,
     selectedVideoIds: selectedVideos.map((v) => v.id),
     lastCreditsConsumed,
+    outOfCreditsMessage,
+    dismissOutOfCredits: () => setOutOfCreditsMessage(null),
     setShowModal,
     handleToggleVideo,
     handleStartTraining,

--- a/apps/web/hooks/useSSE.ts
+++ b/apps/web/hooks/useSSE.ts
@@ -92,8 +92,10 @@ export function useSSE<TResult = unknown>(
             onComplete?.(extracted as TResult);
           } else if (data.state === "failed") {
             const errorMsg = data.error || "An unknown error occurred";
-            toast.error("Generation Failed", { description: errorMsg });
-            onFailed?.(errorMsg);
+            // A caller with onFailed reports the failure itself — as its own toast,
+            // or as a dialog. Toasting here too would double up, or contradict it.
+            if (onFailed) onFailed(errorMsg);
+            else toast.error("Generation Failed", { description: errorMsg });
           }
 
           setIsActive(false);

--- a/packages/ui/src/floating-dock.tsx
+++ b/packages/ui/src/floating-dock.tsx
@@ -71,7 +71,13 @@ const FloatingDockMobile = ({
         )}
       </AnimatePresence>
       <button
+        type="button"
         onClick={() => setOpen(!open)}
+        // Icon-only toggle: without a name a screen reader announces just "button".
+        // The name has to stay stable across states, so the open/closed state rides
+        // on aria-expanded rather than on the label.
+        aria-label="Social links"
+        aria-expanded={open}
         className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-50 dark:bg-neutral-800"
       >
         <IconLayoutNavbarCollapse className="h-5 w-5 text-neutral-500 dark:text-neutral-400" />

--- a/packages/workers/src/processor/utils/train-ai.ts
+++ b/packages/workers/src/processor/utils/train-ai.ts
@@ -508,12 +508,26 @@ export async function saveStyleData(
     { tokensPerCredit, multiplier: trainAiMultiplier, minimumCredits: 1 },
   );
 
-  const { data: profile } = await supabase.from('profiles').select('credits').eq('user_id', userId).single();
-  if (profile.credits < geminiCredits) {
-    throw new Error('Insufficient credits, Please upgrade your plan.');
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('credits')
+    .eq('user_id', userId)
+    .single();
+  if (profileError || !profile) {
+    logError('train-ai-profile-fetch', profileError, { userId });
+    throw new Error('Could not load your account to charge for training.');
   }
 
-  await supabase.from('profiles').update({ credits: profile.credits - geminiCredits, ai_trained: true }).eq('user_id', userId);
+  // Same "Insufficient credits." opening as the dubbing, thumbnail and video
+  // processors — the dashboard keys its out-of-credits dialog off that prefix.
+  const credits = profile.credits ?? 0;
+  if (credits < geminiCredits) {
+    throw new Error(
+      `Insufficient credits. This training needed ${geminiCredits} credits but you have ${credits}. Please upgrade your plan and train again.`,
+    );
+  }
+
+  await supabase.from('profiles').update({ credits: credits - geminiCredits, ai_trained: true }).eq('user_id', userId);
 
   const styleData: Record<string, any> = {
     user_id: userId,


### PR DESCRIPTION
## What

Running out of credits during AI training surfaced as a generic **"Training Failed"** toast carrying the raw worker string — easy to miss, and with no route to fixing it. It's the one training failure the user can actually act on, so it now opens a dialog that says what happened and offers both ways out.

Three commits, reviewable independently.

### `feat(train-ai): show a clear out-of-credits dialog when training fails`

- New `OutOfCreditsDialog` (`components/dashboard/common/`) — icon, the message from the failed run, and two routes: **Earn more credits** → `/dashboard/referrals` and **Get more credits** → `settings?tab=billing`. The free route sits first, and the dialog's own close button handles dismissing. Responsive and theme-aware; built on the existing `@repo/ui/dialog`.
- `saveStyleData` keeps the check exactly where it always was — **after** the run, since that's the only point the real token count exists. There is no pre-flight estimate and nothing is shown to the user before they train.
- Its message now opens with `Insufficient credits.` to match the dubbing, thumbnail and video processors, and carries the real numbers (`needed X, you have Y`). The dashboard keys the dialog off that prefix; every other failure still toasts as before.
- It also no longer dereferences `profile` without checking the fetch — a failed lookup crashed on `undefined` instead of reporting.
- `useSSE` no longer toasts a failure when the caller passes `onFailed`. Both callers (`useAITraining`, `useIdeation`) already toast in their own handler, so this was a duplicate toast on every failure today — and it would have contradicted the new dialog.

Success is unchanged: `toast.success` plus the existing `SuccessDialog`, with credits consumed already shown in the training header.

### `fix(a11y): name the pricing links and dock toggle, add WebSite schema`

Unrelated leftovers from the last a11y pass:

- All four pricing cards render the same "Get Started" text, so the links were indistinguishable to a screen reader. Plan name now goes in the accessible name.
- The mobile dock toggle is icon-only and announced as bare "button" — gets `aria-label` plus `aria-expanded` for state, and an explicit `type` so it never submits a form.
- Adds `WebSite` JSON-LD with `alternateName` so Google renders the right site title in search results.

## Testing

`tsc --noEmit` clean on `apps/web` and `packages/workers`. The failure path itself is not covered by an automated test — it needs a real job to fail against a low-credit profile.
