### PR TITLE
fix(blog): make the embedded video pass Google's watch-page check

### DIFF
--- a/apps/web/app/blog/[id]/layout.tsx
+++ b/apps/web/app/blog/[id]/layout.tsx
@@ -126,7 +126,9 @@ export default async function BlogPostLayout({
     uploadDate: toIsoDate(video.uploadDate),
     ...(video.duration ? { duration: video.duration } : {}),
     contentUrl: `https://www.youtube.com/watch?v=${video.youtubeId}`,
-    embedUrl: `https://www.youtube.com/embed/${video.youtubeId}`,
+    // Must match the iframe src rendered by markdownComponents.tsx — Google
+    // cross-checks embedUrl against the actual player on the page.
+    embedUrl: `https://www.youtube-nocookie.com/embed/${video.youtubeId}`,
     publisher: {
       "@type": "Organization",
       name: siteConfig.name,

--- a/apps/web/components/blog/markdownComponents.tsx
+++ b/apps/web/components/blog/markdownComponents.tsx
@@ -132,7 +132,6 @@ export const markdownComponents: Components = {
               title={caption}
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowFullScreen
-              loading="lazy"
               className="h-full w-full"
             />
           </span>

--- a/apps/web/lib/blog-data.ts
+++ b/apps/web/lib/blog-data.ts
@@ -3191,11 +3191,11 @@ Pair AI scripting with [how to write YouTube scripts that get more views](/blog/
     content: `
 > **Does YouTube auto-dubbing use your real voice?** No. YouTube's native auto-dubbing uses a generic synthesized voice, not a clone of the creator. It translates your words into 27 languages for free, but viewers in those languages hear a competent stranger, not you. AI voice cloning tools like Creator AI preserve your actual voice so the dub still sounds like the person your audience subscribed to.
 
+![AI voice cloning walkthrough: dub YouTube videos in your own voice with Creator AI](https://www.youtube.com/watch?v=Yg4J8mUJo-M)
+
 YouTube's native auto-dubbing went fully public in early 2026. As of February it covers 27 languages and is open to essentially every eligible creator, not just Partner Program members. YouTube reported that in December 2025 more than 6 million people per day watched at least 10 minutes of auto-dubbed content. The demand is real and validated.
 
 So the question in 2026 isn't *should* you dub. YouTube already settled that. The question is *with what voice*, because the free default ships with a hidden cost that doesn't show up until you read your retention graph.
-
-![AI voice cloning walkthrough: dub YouTube videos in your own voice with Creator AI](https://www.youtube.com/watch?v=Yg4J8mUJo-M)
 
 ## Does YouTube Auto-Dubbing Use Your Real Voice?
 


### PR DESCRIPTION
## 📝 Description

Search Console reports **"Video isn't on a watch page"** for the two dubbing posts, so the embedded walkthrough is excluded from Google video results. This fixes the three causes that are on our side.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- [x] I have tested my changes locally
- [x] All existing tests pass

Verified against the live page before the change (`curl` of the rendered HTML confirmed both the `youtube.com/embed` schema value and the `youtube-nocookie.com` iframe were present — the mismatch this PR fixes). Also confirmed `maxresdefault.jpg` returns 200 and the video is public via oembed, ruling those out as causes.

## 🔧 Technical Details

- **`embedUrl` didn't match the rendered player.** The `VideoObject` in `apps/web/app/blog/[id]/layout.tsx` declared `youtube.com/embed/<id>`, but the article renders a `youtube-nocookie.com` iframe. Google cross-checks the declared player URL against what's on the page; the mismatch reads as "no player here."
- **The player was lazy-loaded.** Google's video indexing docs list lazy-loaded players as a reason a video is never seen. Dropped `loading="lazy"` from the video iframe in `markdownComponents.tsx` only — images still lazy-load.
- **The embed sat below the fold** on the auto-dubbing post (three paragraphs in). Moved it directly under the opening answer block, matching the other post, to support the "video is the main content" signal.

The schema and `role="figure"` semantics were already correct and are unchanged.

## 🚀 Deployment Notes

**Re-request validation in Search Console after this deploys.** The current "failed" verdict is from 7/20 — five days before the video markup shipped (`8658f4a`) — so it never saw any of this.

## 🔍 Review Notes

This may not fully clear the report, and that's expected. Google's watch-page rule is that the video must be the page's **main content** — on a long-form comparison article the main content is the text, so exclusion can persist regardless of markup. Both posts also embed the same video (`Yg4J8mUJo-M`), and one video gets exactly one canonical watch page, so at most one of them can ever win.

If revalidation still fails after deploy, the reliable fix is a dedicated page per video (`/watch/<slug>`: video at top, transcript below, articles linking in). Not built here — worth a separate call on whether it's worth the pages.

## 📊 Performance Impact

- [x] Performance improvement

Removing `loading="lazy"` costs one extra above-the-fold iframe request on two blog posts; moving the embed above the fold means it would have loaded eagerly regardless. Negligible either way.

## 🔒 Security Considerations

- [x] No security implications