### PR TITLE
feat(ideation): rename header, restyle form, add Surprise me

### DIFF
--- a/apps/api/src/ideation/ideation.controller.ts
+++ b/apps/api/src/ideation/ideation.controller.ts
@@ -32,6 +32,14 @@ export class IdeationController {
     return this.ideationService.createJob(getUserId(req), body);
   }
 
+  @Post('surprise')
+  @UseGuards(SupabaseAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Suggest a niche focus from the creator\'s trained style' })
+  async surprise(@Req() req: AuthRequest) {
+    return this.ideationService.surpriseNiche(getUserId(req));
+  }
+
   @Get()
   @UseGuards(SupabaseAuthGuard)
   @ApiBearerAuth()

--- a/apps/api/src/ideation/ideation.service.ts
+++ b/apps/api/src/ideation/ideation.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  Logger,
   ForbiddenException,
   InternalServerErrorException,
   NotFoundException,
@@ -18,6 +19,8 @@ import {
   getIdeationLimitsForPlan,
 } from '@repo/validation';
 import { BillingService } from '../billing/billing.service';
+import { ConfigService } from '@nestjs/config';
+import { createGoogleAI, GEMINI_TEXT_MODEL } from '../utils/genai';
 import { PDFDocument, PDFPage, PDFImage, rgb, StandardFonts, PDFFont } from 'pdf-lib';
 
 const MAX_NICHE_FOCUS_LENGTH = 200;
@@ -36,14 +39,70 @@ const COLORS = {
 
 @Injectable()
 export class IdeationService {
+  private readonly logger = new Logger(IdeationService.name);
+
   constructor(
     private readonly supabaseService: SupabaseService,
     private readonly billingService: BillingService,
+    private readonly configService: ConfigService,
     @InjectQueue('ideation') private readonly queue: Queue,
   ) {}
 
   private get supabase() {
     return this.supabaseService.getClient();
+  }
+
+  /**
+   * One niche-focus suggestion for the "Surprise me" button. Free and ungated —
+   * same reasoning as video generation: let people feel the feature before the paywall.
+   */
+  async surpriseNiche(userId: string) {
+    const { data: style } = await this.supabase
+      .from('user_style')
+      .select('tone, visual_style, themes, humor_style, narrative_structure')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    const styleLines = style
+      ? [
+          style.tone && `Tone: ${style.tone}`,
+          style.visual_style && `Visual style: ${style.visual_style}`,
+          style.themes && `Themes: ${style.themes}`,
+          style.humor_style && `Humor: ${style.humor_style}`,
+          style.narrative_structure && `Narrative structure: ${style.narrative_structure}`,
+        ]
+          .filter(Boolean)
+          .join('\n')
+      : '';
+
+    const system = [
+      'You suggest a single niche focus for a YouTube creator about to brainstorm video ideas.',
+      'Return ONLY the niche focus — no preamble, no quotes, no markdown, no list.',
+      'Format it like "AI tools for small business owners": a topic plus the audience it serves. Under 12 words.',
+      styleLines
+        ? `Align it with this creator's established style:\n${styleLines}`
+        : 'The creator has no saved style yet, so pick something broadly appealing with proven search demand.',
+    ].join('\n\n');
+
+    try {
+      const ai = await createGoogleAI(this.configService);
+      const result = await ai.models.generateContent({
+        model: GEMINI_TEXT_MODEL,
+        contents: [{ role: 'user', parts: [{ text: 'Give me one fresh niche focus idea.' }] }],
+        config: { systemInstruction: system, temperature: 1.1, maxOutputTokens: 100 } as any,
+      });
+      const nicheFocus = (
+        (result as any)?.candidates?.[0]?.content?.parts?.[0]?.text ?? result?.text ?? ''
+      )
+        .trim()
+        .replace(/^["']|["']$/g, '')
+        .slice(0, MAX_NICHE_FOCUS_LENGTH);
+      if (!nicheFocus) throw new Error('empty');
+      return { success: true, nicheFocus };
+    } catch (e) {
+      this.logger.error(`Surprise niche failed for user ${userId}: ${(e as Error).message}`);
+      throw new InternalServerErrorException('Could not suggest a niche right now. Please try again.');
+    }
   }
 
   async createJob(userId: string, input: {

--- a/apps/web/app/dashboard/research/new/page.tsx
+++ b/apps/web/app/dashboard/research/new/page.tsx
@@ -10,23 +10,19 @@ import { Label } from "@repo/ui/label";
 import { Textarea } from "@repo/ui/textarea";
 import { Switch } from "@repo/ui/switch";
 import { Skeleton } from "@repo/ui/skeleton";
-import { Sparkles, Loader2, ArrowLeft, Lock } from "lucide-react";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@repo/ui/accordion";
+import { Sparkles, Loader2, ArrowLeft, Lock, Wand2, Compass, Bot, Lightbulb } from "lucide-react";
 import IdeationProgress from "@/components/dashboard/research/IdeationProgress";
 import { useIdeation } from "@/hooks/useIdeation";
 import { useAISetupGate } from "@/hooks/useAISetupGate";
 import { useCurrentPlan } from "@/hooks/useCurrentPlan";
 import Link from "next/link";
 
-const NICHE_EXAMPLES = [
-  "AI tools for small business owners",
-  "Budget travel hacks for solo travelers",
-  "Home workouts for busy professionals",
-];
-
+// Same three-step card style as AI Studio's HowItWorksGuide.
 const HOW_IT_WORKS_STEPS = [
-  "Choose Auto mode or set a niche focus.",
-  "Add optional context for audience or constraints.",
-  "Generate ideas and review the best opportunities.",
+  { step: 1, title: "Set a direction", desc: "Turn on Auto mode, or name the niche you want ideas for.", icon: Compass },
+  { step: 2, title: "AI finds the gaps", desc: "We scan trends and competitors for openings your channel can win.", icon: Bot },
+  { step: 3, title: "Pick your winners", desc: "Review scored ideas and take the best ones straight into a script.", icon: Lightbulb },
 ];
 
 export default function NewIdeationPage() {
@@ -40,7 +36,7 @@ export default function NewIdeationPage() {
     nicheFocus, setNicheFocus,
     setIdeaCount,
     autoMode, setAutoMode,
-    isGenerating,
+    isGenerating, isSurprising, surpriseNiche,
     progress,
     statusMessage,
     generatedResult,
@@ -119,23 +115,33 @@ export default function NewIdeationPage() {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -12 }}
           >
-            <motion.div
-              className="flex items-center justify-between rounded-lg border border-slate-200 dark:border-slate-800 px-4 py-3"
-              whileHover={{ borderColor: "rgba(147, 51, 234, 0.3)" }}
+            <motion.label
+              htmlFor="autoMode"
+              className={`flex items-center gap-4 rounded-xl border px-4 py-4 cursor-pointer transition-colors ${
+                autoMode
+                  ? "border-purple-300 bg-purple-50/60 dark:border-purple-800 dark:bg-purple-900/20"
+                  : "border-slate-200 dark:border-slate-800 hover:border-purple-200 dark:hover:border-purple-900"
+              }`}
+              whileTap={{ scale: 0.995 }}
               transition={{ duration: 0.2 }}
             >
-              <motion.div
-                initial={{ opacity: 0, x: -8 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: 0.05 }}
+              <span
+                className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg transition-colors ${
+                  autoMode
+                    ? "bg-gradient-to-br from-purple-600 to-indigo-600 text-white"
+                    : "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400"
+                }`}
               >
-                <Label className="text-sm font-medium">Auto mode</Label>
-                <p className="text-xs text-slate-500 mt-0.5">
+                <Sparkles className="h-5 w-5" />
+              </span>
+              <span className="flex-1">
+                <span className="block text-sm font-medium text-slate-900 dark:text-slate-100">Auto mode</span>
+                <span className="block text-xs text-slate-500 mt-0.5">
                   AI picks topics from your channel and trends
-                </p>
-              </motion.div>
-              <Switch checked={autoMode} onCheckedChange={setAutoMode} />
-            </motion.div>
+                </span>
+              </span>
+              <Switch id="autoMode" checked={autoMode} onCheckedChange={setAutoMode} />
+            </motion.label>
 
             {!autoMode && (
               <motion.div
@@ -143,7 +149,30 @@ export default function NewIdeationPage() {
                 initial={{ opacity: 0, height: 0 }}
                 animate={{ opacity: 1, height: "auto" }}
               >
-                <Label htmlFor="nicheFocus">Niche focus</Label>
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="nicheFocus">Niche focus</Label>
+                  {/* Surprise me — on-brand niche from the creator's trained style. */}
+                  <motion.button
+                    type="button"
+                    onClick={surpriseNiche}
+                    disabled={isSurprising || isGenerating}
+                    whileHover={{ scale: 1.04 }}
+                    whileTap={{ scale: 0.96 }}
+                    className="group relative inline-flex items-center gap-1.5 rounded-full bg-gradient-to-r from-purple-600 to-indigo-600 px-3 py-1.5 text-xs font-medium text-white shadow-sm disabled:opacity-60"
+                  >
+                    {isSurprising ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <motion.span
+                        animate={{ rotate: [0, -12, 12, 0] }}
+                        transition={{ repeat: Infinity, repeatDelay: 2.5, duration: 0.8 }}
+                      >
+                        <Wand2 className="h-3.5 w-3.5" />
+                      </motion.span>
+                    )}
+                    Surprise me
+                  </motion.button>
+                </div>
                 <Input
                   id="nicheFocus"
                   placeholder="e.g. AI tools for developers"
@@ -151,32 +180,6 @@ export default function NewIdeationPage() {
                   onChange={(e) => setNicheFocus(e.target.value)}
                   maxLength={200}
                 />
-                <motion.div
-                  className="flex flex-wrap gap-2"
-                  initial="hidden"
-                  animate="visible"
-                  variants={{
-                    hidden: {},
-                    visible: { transition: { staggerChildren: 0.05 } },
-                  }}
-                >
-                  {NICHE_EXAMPLES.map((example) => (
-                    <motion.button
-                      key={example}
-                      type="button"
-                      variants={{
-                        hidden: { opacity: 0, scale: 0.95 },
-                        visible: { opacity: 1, scale: 1 },
-                      }}
-                      whileHover={{ scale: 1.02 }}
-                      whileTap={{ scale: 0.98 }}
-                      onClick={() => setNicheFocus(example)}
-                      className="text-xs px-3 py-1 rounded-full bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-purple-100 dark:hover:bg-purple-900/30 transition-colors"
-                    >
-                      {example}
-                    </motion.button>
-                  ))}
-                </motion.div>
               </motion.div>
             )}
 
@@ -267,16 +270,30 @@ export default function NewIdeationPage() {
       >
         {showHowItWorks && (
           <motion.div
-            className="lg:col-span-4 lg:sticky lg:top-8 rounded-lg border border-slate-200 dark:border-slate-800 p-4"
+            className="lg:col-span-4 lg:sticky lg:top-8 rounded-lg border border-slate-200 dark:border-slate-800 px-4"
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
           >
-            <h2 className="text-sm font-semibold text-slate-900 dark:text-slate-100">How it works</h2>
-            <ul className="mt-2 space-y-1.5 text-sm text-slate-600 dark:text-slate-300">
-              {HOW_IT_WORKS_STEPS.map((step) => (
-                <li key={step}>- {step}</li>
-              ))}
-            </ul>
+            <Accordion type="single" collapsible defaultValue="how-it-works" className="w-full">
+              <AccordionItem value="how-it-works" className="border-b-0">
+                <AccordionTrigger className="font-semibold">How does ideation work?</AccordionTrigger>
+                <AccordionContent className="pt-4">
+                  <div className="space-y-6">
+                    {HOW_IT_WORKS_STEPS.map(({ step, title, desc, icon: Icon }) => (
+                      <div key={step} className="flex items-start gap-4">
+                        <div className="flex items-center justify-center h-9 w-9 rounded-lg bg-purple-100 text-purple-600 dark:bg-purple-900/30 dark:text-purple-400 shrink-0">
+                          <Icon className="h-5 w-5" />
+                        </div>
+                        <div className="pt-0.5">
+                          <h3 className="font-semibold text-slate-800 dark:text-slate-200">{title}</h3>
+                          <p className="text-sm text-slate-600 dark:text-slate-400">{desc}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
           </motion.div>
         )}
 

--- a/apps/web/components/dashboard-header.tsx
+++ b/apps/web/components/dashboard-header.tsx
@@ -12,6 +12,12 @@ import { useSupabase } from "@/components/supabase-provider";
 import { toast } from "sonner";
 import { Separator } from "@repo/ui/separator";
 
+// Route segments whose display name differs from the URL.
+const SEGMENT_TITLES: Record<string, string> = {
+  research: "Ideation",
+  train: "AI Studio",
+};
+
 export default function DashboardHeader() {
   const pathname = usePathname();
   const { user, profile: initialProfile, logout } = useSupabase();
@@ -29,7 +35,9 @@ export default function DashboardHeader() {
     if (path.length === 1) {
       setPageTitle("Dashboard");
     } else {
-      const title = path[1] ? path[1].charAt(0).toUpperCase() + path[1].slice(1) : "";
+      const segment = path[1] ?? "";
+      const title = SEGMENT_TITLES[segment]
+        ?? (segment ? segment.charAt(0).toUpperCase() + segment.slice(1) : "");
       setPageTitle(title);
     }
     // Close the popover when the pathname changes

--- a/apps/web/hooks/useIdeation.ts
+++ b/apps/web/hooks/useIdeation.ts
@@ -41,6 +41,7 @@ export function useIdeation() {
   const [autoMode, setAutoMode] = useState(false);
 
   const [isGenerating, setIsGenerating] = useState(false);
+  const [isSurprising, setIsSurprising] = useState(false);
   const [jobId, setJobId] = useState<string | null>(null);
   const [activeJobDbId, setActiveJobDbId] = useState<string | null>(null);
 
@@ -115,6 +116,24 @@ export function useIdeation() {
     },
   });
 
+  const surpriseNiche = async () => {
+    setIsSurprising(true);
+    try {
+      const res = await api.post<{ success: boolean; nicheFocus: string }>(
+        "/api/v1/ideation/surprise",
+        {},
+        { requireAuth: true },
+      );
+      if (res.nicheFocus) setNicheFocus(res.nicheFocus);
+    } catch (error) {
+      toast.error("Couldn't dream one up", {
+        description: getApiErrorMessage(error, "Please try again."),
+      });
+    } finally {
+      setIsSurprising(false);
+    }
+  };
+
   const handleGenerate = async (countOverride?: number) => {
     const effectiveCount = countOverride ?? ideaCount;
     setIsGenerating(true);
@@ -169,13 +188,14 @@ export function useIdeation() {
     nicheFocus, setNicheFocus,
     ideaCount, setIdeaCount,
     autoMode, setAutoMode,
-    isGenerating,
+    isGenerating, isSurprising,
     progress: sse.progress,
     statusMessage: sse.statusMessage,
     generatedResult,
     activeJobDbId,
     jobs, isLoadingJobs,
     aiTrained, credits, isLoadingProfile,
+    surpriseNiche,
     handleGenerate,
     handleDeleteJob,
     clearForm,

--- a/packages/validations/src/consts/ideation.ts
+++ b/packages/validations/src/consts/ideation.ts
@@ -7,7 +7,7 @@ export interface IdeationLimits {
   comparisonMetrics: boolean;
 }
 
-const UNLOCKED_LIMITS: IdeationLimits = { maxIdeas: 20, comparisonMetrics: true };
+const UNLOCKED_LIMITS: IdeationLimits = { maxIdeas: 10, comparisonMetrics: true };
 
 export const IDEATION_PLAN_LIMITS: Record<string, IdeationLimits> = {
   Starter: UNLOCKED_LIMITS,
@@ -19,7 +19,7 @@ export const IDEATION_PLAN_LIMITS: Record<string, IdeationLimits> = {
 
 export type IdeationPlanName = keyof typeof IDEATION_PLAN_LIMITS;
 
-export const IDEATION_ABSOLUTE_MAX_IDEAS = 20;
+export const IDEATION_ABSOLUTE_MAX_IDEAS = 10;
 
 export function getIdeationLimitsForPlan(_planName?: string | null): IdeationLimits {
   // Uniform across all plans — no feature gating.


### PR DESCRIPTION
## What

Polish pass on the ideation (`/dashboard/research`) page.

- **Header says "Ideation"**, not "Research". The dashboard header derived its title from the URL segment; added a small segment→title map (`research` → Ideation, `train` → AI Studio) rather than renaming the route.
- **How it works** now uses the same accordion + icon-step layout as AI Studio's `HowItWorksGuide`, with ideation-specific copy.
- **Auto mode** is a full clickable card with a gradient icon and an active state, instead of a plain bordered row.
- **Niche focus**: the three static example chips are gone, replaced by a **Surprise me** button matching the video generation page. Backed by a new `POST /api/v1/ideation/surprise` that suggests a niche from the creator's trained style — ungated, same reasoning as the video prompt helper.
- **Max ideas per run: 20 → 10** for every plan (`IDEATION_PLAN_LIMITS` + `IDEATION_ABSOLUTE_MAX_IDEAS`).

## Notes

- `@repo/validation` needs a rebuild for the new limit to show up in the web app (it imports from `dist/`).
- The surprise result fills the input directly; no typewriter animation like the video prompt has.

## Testing

`tsc --noEmit` clean on both `apps/api` and `apps/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
