### PR TITLE
fix(api): require AI training and YouTube on every paid feature

### DIFF
--- a/apps/api/src/dubbing/dubbing.controller.ts
+++ b/apps/api/src/dubbing/dubbing.controller.ts
@@ -13,6 +13,7 @@ import {
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { createJobSSE } from '../common/sse';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { OnboardedGuard } from '../guards/onboarded.guard';
 import type { AuthRequest } from '../common/interfaces/auth-request.interface';
 
 @ApiTags('dubbing')
@@ -32,7 +33,7 @@ export class DubbingController {
   }
 
   @Post('sign-upload')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Get a signed URL to upload source media to GCS',
@@ -61,7 +62,7 @@ export class DubbingController {
   }
 
   @Post()
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Create a dubbing job from an uploaded object',
@@ -90,7 +91,7 @@ export class DubbingController {
   }
 
   @Post(':id/regenerate')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Regenerate a dub from its original media',

--- a/apps/api/src/guards/onboarded.guard.spec.ts
+++ b/apps/api/src/guards/onboarded.guard.spec.ts
@@ -1,0 +1,64 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { OnboardedGuard } from './onboarded.guard';
+import { SupabaseService } from '../supabase/supabase.service';
+
+type Profile = { ai_trained: boolean; youtube_connected: boolean } | null;
+
+function makeGuard(profile: Profile, error: unknown = null) {
+  const chain = {
+    select: jest.fn(() => chain),
+    eq: jest.fn(() => chain),
+    single: jest.fn(async () => ({ data: profile, error })),
+  };
+  const supabase = { getClient: () => ({ from: jest.fn(() => chain) }) };
+  return new OnboardedGuard(supabase as unknown as SupabaseService);
+}
+
+const ctx = (userId?: string) =>
+  ({
+    switchToHttp: () => ({ getRequest: () => ({ user: userId ? { id: userId } : undefined }) }),
+  }) as unknown as ExecutionContext;
+
+describe('OnboardedGuard', () => {
+  it('lets a fully onboarded user through', async () => {
+    const guard = makeGuard({ ai_trained: true, youtube_connected: true });
+    await expect(guard.canActivate(ctx('u1'))).resolves.toBe(true);
+  });
+
+  // The bug this guard exists for: dubbing charged users who had neither.
+  it('blocks when both are missing, and names both', async () => {
+    const guard = makeGuard({ ai_trained: false, youtube_connected: false });
+    await expect(guard.canActivate(ctx('u1'))).rejects.toThrow(
+      'This feature requires AI training and a connected YouTube channel.',
+    );
+  });
+
+  // Requirement is AND, not OR — one of the two is not enough.
+  it('blocks when only training is missing', async () => {
+    const guard = makeGuard({ ai_trained: false, youtube_connected: true });
+    await expect(guard.canActivate(ctx('u1'))).rejects.toThrow('This feature requires AI training.');
+  });
+
+  it('blocks when only YouTube is missing', async () => {
+    const guard = makeGuard({ ai_trained: true, youtube_connected: false });
+    await expect(guard.canActivate(ctx('u1'))).rejects.toThrow(
+      'This feature requires a connected YouTube channel.',
+    );
+  });
+
+  // Null columns on an older profile row must fail closed, not sail through.
+  it('fails closed on null flags', async () => {
+    const guard = makeGuard({ ai_trained: null, youtube_connected: null } as never);
+    await expect(guard.canActivate(ctx('u1'))).rejects.toThrow(ForbiddenException);
+  });
+
+  it('rejects a missing profile', async () => {
+    const guard = makeGuard(null, { message: 'no rows' });
+    await expect(guard.canActivate(ctx('u1'))).rejects.toThrow('Profile not found');
+  });
+
+  it('rejects an unauthenticated request', async () => {
+    const guard = makeGuard({ ai_trained: true, youtube_connected: true });
+    await expect(guard.canActivate(ctx())).rejects.toThrow('Authentication required');
+  });
+});

--- a/apps/api/src/guards/onboarded.guard.ts
+++ b/apps/api/src/guards/onboarded.guard.ts
@@ -1,0 +1,42 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { SupabaseService } from '../supabase/supabase.service';
+
+/**
+ * Every credit-spending feature requires a trained AI *and* a connected YouTube
+ * channel. This lived as a hand-written check inside subtitle and ideation only,
+ * which is how dubbing and video-generation ended up chargeable by users who had
+ * neither. Applying it as a guard makes the requirement declarative: a new route
+ * either lists it in @UseGuards or it deliberately doesn't need it.
+ *
+ * Order matters — it must follow SupabaseAuthGuard, which is what sets request.user.
+ */
+@Injectable()
+export class OnboardedGuard implements CanActivate {
+  constructor(private readonly supabaseService: SupabaseService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const userId = request.user?.id;
+    if (!userId) throw new ForbiddenException('Authentication required');
+
+    const { data: profile, error } = await this.supabaseService
+      .getClient()
+      .from('profiles')
+      .select('ai_trained, youtube_connected')
+      .eq('user_id', userId)
+      .single();
+
+    if (error || !profile) throw new ForbiddenException('Profile not found');
+
+    const missing: string[] = [];
+    if (!profile.ai_trained) missing.push('AI training');
+    if (!profile.youtube_connected) missing.push('a connected YouTube channel');
+    if (missing.length > 0) {
+      throw new ForbiddenException(`This feature requires ${missing.join(' and ')}.`);
+    }
+
+    // Downstream services re-read the profile for credits; these two are already
+    // proven here, so nothing below needs to check them again.
+    return true;
+  }
+}

--- a/apps/api/src/ideation/ideation.controller.ts
+++ b/apps/api/src/ideation/ideation.controller.ts
@@ -8,6 +8,7 @@ import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import type { Observable } from 'rxjs';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { OnboardedGuard } from '../guards/onboarded.guard';
 import type { AuthRequest } from '../common/interfaces/auth-request.interface';
 import { getUserId } from '../common/get-user-id';
 import { createJobSSE } from '../common/sse';
@@ -22,7 +23,7 @@ export class IdeationController {
   ) {}
 
   @Post()
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Queue ideation job' })
   async create(
@@ -33,7 +34,7 @@ export class IdeationController {
   }
 
   @Post('surprise')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Suggest a niche focus from the creator\'s trained style' })
   async surprise(@Req() req: AuthRequest) {

--- a/apps/api/src/ideation/ideation.service.ts
+++ b/apps/api/src/ideation/ideation.service.ts
@@ -131,14 +131,11 @@ export class IdeationService {
 
     const { data: profile, error: profileError } = await this.supabase
       .from('profiles')
-      .select('credits, ai_trained')
+      .select('credits')
       .eq('user_id', userId)
       .single();
 
     if (profileError || !profile) throw new NotFoundException('Profile not found');
-    if (!profile.ai_trained) {
-      throw new ForbiddenException('AI training is required before generating ideas. Train your AI first.');
-    }
     const ideationMultiplier = this.getEnvNumber(
       'IDEATION_CREDIT_MULTIPLIER',
       IDEATION_CREDIT_MULTIPLIER,

--- a/apps/api/src/script/script.controller.ts
+++ b/apps/api/src/script/script.controller.ts
@@ -9,6 +9,7 @@ import { Queue } from 'bullmq';
 import type { Response } from 'express';
 import type { Observable } from 'rxjs';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { OnboardedGuard } from '../guards/onboarded.guard';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { CreateScriptSchema, type CreateScriptInput } from '@repo/validation';
 import { getUserId } from '../common/get-user-id';
@@ -26,7 +27,7 @@ export class ScriptController {
   ) {}
 
   @Post('generate')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Queue script generation (multipart: fields + optional files)' })
   @ApiMultipartForm({

--- a/apps/api/src/story-builder/story-builder.controller.ts
+++ b/apps/api/src/story-builder/story-builder.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags, ApiBearerAuth, ApiOperation, ApiParam, ApiBody } from '@nestjs
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { OnboardedGuard } from '../guards/onboarded.guard';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { CreateStoryBuilderSchema, type CreateStoryBuilderInput } from '@repo/validation';
 import type { Observable } from 'rxjs';
@@ -20,7 +21,7 @@ export class StoryBuilderController {
   ) {}
 
   @Post('generate')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Queue story-builder job' })
   @ApiBody({

--- a/apps/api/src/subtitle/subtitle.controller.ts
+++ b/apps/api/src/subtitle/subtitle.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags, ApiBearerAuth, ApiOperation, ApiParam, ApiBody } from '@nestjs
 import { createReadStream } from 'fs';
 import { SubtitleService } from './subtitle.service';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { OnboardedGuard } from '../guards/onboarded.guard';
 import type { Response } from 'express';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import type { AuthRequest } from '../common/interfaces/auth-request.interface';
@@ -31,6 +32,7 @@ export class SubtitleController {
   constructor(private readonly subtitleService: SubtitleService) { }
 
   @Post()
+  @UseGuards(OnboardedGuard)
   @ApiOperation({ summary: 'Create subtitle record' })
   @ApiBody({
     schema: {
@@ -75,6 +77,7 @@ export class SubtitleController {
   }
 
   @Post('upload/sign')
+  @UseGuards(OnboardedGuard)
   @ApiOperation({ summary: 'Get a signed URL to upload the video directly to storage' })
   @ApiBody({
     schema: {
@@ -99,6 +102,7 @@ export class SubtitleController {
   }
 
   @Post('upload/finalize')
+  @UseGuards(OnboardedGuard)
   @ApiOperation({ summary: 'Create the subtitle job after the direct upload completes' })
   @ApiBody({
     schema: {
@@ -209,6 +213,7 @@ export class SubtitleController {
   }
 
   @Post('burn')
+  @UseGuards(OnboardedGuard)
   @ApiOperation({ summary: 'Burn subtitles into video (returns MP4 stream)' })
   @ApiBody({
     schema: {

--- a/apps/api/src/subtitle/subtitle.service.ts
+++ b/apps/api/src/subtitle/subtitle.service.ts
@@ -68,18 +68,13 @@ export class SubtitleService {
     try {
       const { data: profileData, error: profileError } = await this.supabaseService.getClient()
         .from('profiles')
-        .select('credits, ai_trained, youtube_connected')
+        .select('credits')
         .eq('user_id', userId)
         .single();
 
       if (profileError || !profileData) {
         await this.logErrorToDB('Profile not found or profile fetch failed', subtitleId);
         throw new NotFoundException('Profile not found');
-      }
-
-      if (!profileData.ai_trained && !profileData.youtube_connected) {
-        await this.logErrorToDB('AI training and YouTube connection are required', subtitleId);
-        throw new ForbiddenException('AI training and YouTube connection are required');
       }
 
       const subtitleMultiplier = this.getEnvNumber(

--- a/apps/api/src/thumbnail/thumbnail.controller.ts
+++ b/apps/api/src/thumbnail/thumbnail.controller.ts
@@ -16,6 +16,7 @@ import { FileFieldsInterceptor } from '@nestjs/platform-express';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { OnboardedGuard } from '../guards/onboarded.guard';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { CreateThumbnailSchema, type CreateThumbnailInput } from '@repo/validation';
 import type { AuthRequest } from '../common/interfaces/auth-request.interface';
@@ -34,7 +35,7 @@ export class ThumbnailController {
   ) { }
 
   @Post('generate')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Queue thumbnail generation (optional reference + face images)' })
   @ApiMultipartForm({

--- a/apps/api/src/video-generation/video-generation.controller.ts
+++ b/apps/api/src/video-generation/video-generation.controller.ts
@@ -13,6 +13,7 @@ import { ApiTags, ApiBearerAuth, ApiOperation, ApiParam, ApiBody } from '@nestjs
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
+import { OnboardedGuard } from '../guards/onboarded.guard';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import {
   CreateVideoGenerationSchema,
@@ -45,7 +46,7 @@ export class VideoGenerationController {
   }
 
   @Post('surprise')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Generate an on-brand video prompt from the creator\'s trained style' })
   async surprise(
@@ -56,7 +57,7 @@ export class VideoGenerationController {
   }
 
   @Post('generate')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Queue an Omni Flash video generation (Pro/Business/Scale plans only)' })
   @ApiBody({
@@ -87,7 +88,7 @@ export class VideoGenerationController {
   }
 
   @Post(':id/edit')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Statefully edit a finished video (Omni previous_interaction_id)' })
   @ApiParam({ name: 'id' })


### PR DESCRIPTION
## The bug

A Starter account with `ai_trained: false` and `youtube_connected: false` ran a dub and burned **465 credits** — while the same account got a 403 on subtitles. The requirement was real, it just wasn't shared.

It lived as a hand-written check in exactly two services:

| service | check |
|---|---|
| `subtitle.service.ts` | `!ai_trained && !youtube_connected` — blocks only when **both** are missing, i.e. an OR, despite the message reading "AI training and YouTube connection are required" |
| `ideation.service.ts` | `!ai_trained` |

`script`, `story-builder` and `thumbnail` read `ai_trained` only to set `shouldPersonalize`, so an untrained user got generic output rather than a block. `dubbing`, `video-generation` and `course` never looked at either column.

## The fix

`OnboardedGuard`, mirroring the `RolesGuard` already in `apps/api/src/guards`: one indexed profile lookup, both flags required, and a message naming whichever is missing so the client can tell the user what to do.

Applied to the 15 routes that spend credits or accept an upload:

| feature | routes |
|---|---|
| dubbing | `POST sign-upload`, `POST /`, `POST :id/regenerate` |
| video-generation | `POST generate`, `POST :id/edit`, `POST surprise` |
| subtitle | `POST /`, `POST upload/sign`, `POST upload/finalize`, `POST burn` |
| ideation | `POST /`, `POST surprise` |
| script / thumbnail / story-builder | `POST generate` |

Not gated, deliberately: list/detail GETs, SSE status, DELETE, stop/cancel, and the `access` / `profile-status` endpoints — the dashboard needs those to render the connect-your-channel state, and locking a user out of work they already paid for would be a second bug. `train-ai` and `youtube` stay open, since they're how the requirement gets satisfied.

Both inline checks are deleted and their profile queries narrowed to `select('credits')`; the flags are proven upstream now. Net −21 lines in the services.

## Heads-up before merging

**This is a behaviour change, not just a refactor.** The requirement is now AND:

- Users with only one of the two lose access where subtitle previously accepted either.
- Every un-onboarded user loses dubbing and video-generation entirely — including the account in the report above.

**The frontend doesn't know yet.** Dubbing and video-gen read `GET /access`, which still reports plan only, so those forms will render and fail at submit with a 403 rather than showing the upgrade/connect card. Worth a follow-up to have `getAccess` return the two flags.

## Verification

- New spec `onboarded.guard.spec.ts`, 7 cases — including the AND semantics (one of two is not enough, which is what the old subtitle check got wrong) and null flags failing closed.
- Full API suite: 15 suites, 101 tests, passing.
- `tsc --noEmit` clean.
