### PR TITLE
feat(dubbing): add Bengali via ElevenLabs dubbing_v1, keep v2 for everyone else

### DIFF
--- a/apps/web/app/dashboard/dubbing/new/page.tsx
+++ b/apps/web/app/dashboard/dubbing/new/page.tsx
@@ -387,7 +387,12 @@ export default function NewDubbing() {
                           <Languages className="h-4 w-4" />
                           Target Language
                         </Label>
-                        <Select value={targetLanguage} onValueChange={setTargetLanguage}>
+                        {/* Clear the accent too: it belongs to the old language, and
+                            most languages (Bengali included) offer none at all. */}
+                        <Select
+                          value={targetLanguage}
+                          onValueChange={(value) => { setTargetLanguage(value); setTargetAccent(""); }}
+                        >
                           <SelectTrigger id="target-language">
                             <SelectValue placeholder="Select a language" />
                           </SelectTrigger>

--- a/packages/validations/src/consts/dubbing.check.ts
+++ b/packages/validations/src/consts/dubbing.check.ts
@@ -11,6 +11,10 @@ import {
   maxDubSecondsForPlan,
   isDubDurationAllowed,
   supportedLanguages,
+  isSupportedDubLanguage,
+  DUBBING_V1_LANGUAGES,
+  usesDubbingV1,
+  accentsFor,
 } from './dubbing';
 import {
   calculateDubbingCreditsByDuration,
@@ -100,15 +104,28 @@ assert.equal(CreateDubSchema.safeParse({ targetLanguage: 'es', isVideo: false, m
 // Cancel prefix is stable — the API sets it, the worker polls it.
 assert.equal(DUBBING_CANCEL_PREFIX, 'dubbing:cancel:');
 
-// The dropdown must mirror what the dubbing API accepts. A language it does not
-// support comes back as audio in the WRONG language rather than an error, so an
-// extra entry here is silently broken output.
-assert.equal(supportedLanguages.length, 29);
+// The dropdown must mirror what the dubbing API accepts: a language neither backend
+// takes is a 400 the user cannot act on.
+assert.equal(supportedLanguages.length, 30);
 const languageCodes = supportedLanguages.map((l) => l.value);
 assert.equal(new Set(languageCodes).size, languageCodes.length, 'duplicate language code');
 assert.equal(languageCodes.includes('no' as never), false, 'Norwegian is flash-v2.5 only');
-for (const code of ['en', 'es', 'ar', 'uk', 'ta', 'fil', 'ms', 'sv', 'zh']) {
+for (const code of ['en', 'es', 'ar', 'uk', 'ta', 'fil', 'ms', 'sv', 'zh', 'bn']) {
   assert.equal(languageCodes.includes(code as never), true, `missing ${code}`);
+}
+assert.equal(isSupportedDubLanguage('bn'), true);
+assert.equal(isSupportedDubLanguage('xx'), false);
+
+// Routing: only the listed languages take the project/dubbing_v1 route, and every one
+// of them must be offered in the dropdown — a code in one list and not the other is a
+// language that either cannot be picked or gets sent to the endpoint that refuses it.
+assert.equal(usesDubbingV1('bn'), true);
+assert.equal(usesDubbingV1('es'), false);
+assert.equal(usesDubbingV1('hi'), false);
+for (const code of DUBBING_V1_LANGUAGES) {
+  assert.equal(languageCodes.includes(code as never), true, `${code} routes via v1 but is not offered`);
+  // dubbing_v1 has no target_accent, so an accent menu there would be a lie.
+  assert.deepEqual(accentsFor(code), [], `${code} routes via v1 and cannot offer accents`);
 }
 for (const { value, label } of supportedLanguages) {
   assert.equal(/^[a-z]{2,3}$/.test(value), true, `not an ISO code: ${value}`);

--- a/packages/validations/src/consts/dubbing.ts
+++ b/packages/validations/src/consts/dubbing.ts
@@ -37,16 +37,19 @@ export function isDubDurationAllowed(planName: string | null | undefined, durati
 export const DUBBING_CANCEL_PREFIX = 'dubbing:cancel:';
 
 /**
- * The 29 target languages the ElevenLabs dubbing API accepts — it synthesises with
- * eleven_multilingual_v2, so this is that model's coverage. Offering anything outside
- * the list produces audio in the wrong language rather than an error, so the dropdown
- * must mirror it exactly.
+ * Every language the dubbing UI offers. Two backends serve this one list:
  *
- * Norwegian was dropped when dubbing moved to ElevenLabs: it only exists on
- * eleven_flash_v2_5, which dubbing does not use.
+ *  - the default: POST /v1/dubbing, which accepts 32 languages and is the only route
+ *    that takes `target_accent` and renders video for us;
+ *  - DUBBING_V1_LANGUAGES below: POST /v1/dubbing/project with `model_id=dubbing_v1`,
+ *    whose coverage is Eleven v3's ~85 languages.
+ *
+ * A language the chosen backend does not accept is rejected outright (400
+ * `unsupported_target_language`), so every entry here must be reachable by one of them.
  */
 export const supportedLanguages = [
   { value: 'ar', label: 'Arabic' },
+  { value: 'bn', label: 'Bengali' },
   { value: 'bg', label: 'Bulgarian' },
   { value: 'cs', label: 'Czech' },
   { value: 'da', label: 'Danish' },
@@ -78,6 +81,26 @@ export const supportedLanguages = [
 ] as const;
 
 export type SupportedLanguage = typeof supportedLanguages[number]['value'];
+
+export function isSupportedDubLanguage(code: string): boolean {
+  return supportedLanguages.some((l) => l.value === code);
+}
+
+/**
+ * Languages the default /v1/dubbing endpoint refuses — it has no model selector and
+ * tops out at its own 32. These route through the dubbing *project* API pinned to
+ * `model_id=dubbing_v1`, which reaches everything Eleven v3 speaks.
+ *
+ * Adding one is two lines: the entry in `supportedLanguages` above and its code here.
+ * The cost is that dubbing_v1 renders audio only (the worker muxes it back over the
+ * source video) and ignores `target_accent`, so a language with accents worth offering
+ * is better left on the default route.
+ */
+export const DUBBING_V1_LANGUAGES: readonly string[] = ['bn'];
+
+export function usesDubbingV1(code: string): boolean {
+  return DUBBING_V1_LANGUAGES.includes(code);
+}
 
 /**
  * Accents the dubbing API can aim for, per language. `target_accent` is marked

--- a/packages/validations/src/schema/dubbing.schema.ts
+++ b/packages/validations/src/schema/dubbing.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { isSupportedDubLanguage } from '../consts/dubbing';
 
 // Step 1: ask the API for a signed URL to PUT the source media straight to GCS.
 // The API plan-gates and enforces size before issuing the URL.
@@ -17,7 +18,12 @@ export const SignDubUploadSchema = z.object({
 // verified object. No raw URL from the client — the API derives it from objectName.
 export const CreateDubSchema = z.object({
   objectName: z.string().min(1, { message: 'objectName is required' }),
-  targetLanguage: z.string().min(1, { message: 'Target language is required' }),
+  // Checked against the offered list, not just non-empty: the language decides which
+  // ElevenLabs backend the worker uses, and an unknown code would pick the wrong one.
+  targetLanguage: z
+    .string()
+    .min(1, { message: 'Target language is required' })
+    .refine(isSupportedDubLanguage, { message: 'Unsupported target language' }),
   targetAccent: z.string().max(40).optional(),
   isVideo: z.boolean(),
   mediaName: z.string().min(1, { message: 'Media name is required' }).max(100),

--- a/packages/workers/src/processor/dubbing.processor.ts
+++ b/packages/workers/src/processor/dubbing.processor.ts
@@ -9,9 +9,17 @@ import {
   isDubDurationAllowed,
   maxDubSecondsForPlan,
   supportedLanguages,
+  usesDubbingV1,
 } from '@repo/validation';
 import { GoogleGenAI } from '@google/genai';
+import { createReadStream, createWriteStream } from 'fs';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
 import { getGenAI, GEMINI_TEXT_MODEL } from './utils/genai';
+import { muxDubbedAudio } from './utils/ffmpeg';
 
 // The clone step (Modal GPU) can run for a few minutes — cap the wait so a hung
 // request fails the job instead of pinning a worker slot forever.
@@ -29,10 +37,23 @@ const MODAL_TIMEOUT_MS = 10 * 60 * 1000;
 //
 // The Modal + Chatterbox path is kept commented at the bottom of this file as the
 // fallback if ElevenLabs disappoints.
+//
+// A handful of languages (Bengali today — see DUBBING_V1_LANGUAGES) are not on that
+// endpoint at all: it has no model selector and refuses them outright. Those go through
+// the dubbing *project* API pinned to model_id=dubbing_v1, which speaks everything
+// Eleven v3 does. It is a different shape — create, poll the project, poll the language,
+// then fetch a signed URL — and it returns an audio track only, so the worker muxes the
+// result back over the source itself. Everything else stays on the endpoint above,
+// accents and all.
 // ─────────────────────────────────────────────────────────────────────────────
 const ELEVENLABS_API = 'https://api.elevenlabs.io/v1';
 const ELEVENLABS_POLL_INTERVAL_MS = 5_000;
 const ELEVENLABS_TIMEOUT_MS = 20 * 60 * 1000;
+
+/** Which backend produced a running dub, and what it takes to follow it up. */
+type DubHandle =
+  | { kind: 'legacy'; dubbingId: string }
+  | { kind: 'project'; projectId: string; languageId: string };
 
 function getElevenLabsKey(): string {
   const key = process.env.ELEVENLABS_API_KEY;
@@ -109,17 +130,20 @@ export class DubbingProcessor extends WorkerHost {
       //    clones the speaker from the source audio and re-times the result. The
       //    bytes never touch this worker on the way in.
       await job.log(`Sending to ElevenLabs for ${languageLabel} dubbing...`);
-      const { dubbingId, expectedDurationSec } = await this.createElevenLabsDub(
-        apiKey, inputUrl, targetLanguage, targetAccent,
-      );
-
-      // durationSeconds came from the browser and set both the price and the plan cap.
-      // This is the first independent reading of it, so check before the expensive
-      // part runs rather than after.
-      if (expectedDurationSec && !isDubDurationAllowed(planName, expectedDurationSec)) {
-        throw new Error(
-          `This clip is ${Math.round(expectedDurationSec)}s, over the ${maxDubSecondsForPlan(planName)}s limit on your plan.`,
+      let handle: DubHandle;
+      if (usesDubbingV1(targetLanguage)) {
+        handle = await this.createDubbingV1Project(apiKey, inputUrl, targetLanguage);
+      } else {
+        const { dubbingId, expectedDurationSec } = await this.createElevenLabsDub(
+          apiKey, inputUrl, targetLanguage, targetAccent,
         );
+        handle = { kind: 'legacy', dubbingId };
+
+        // durationSeconds came from the browser and set both the price and the plan cap.
+        // This is the first independent reading of it, so check before the expensive
+        // part runs rather than after. (The project API reports it a step later, once
+        // the source is probed — see waitForDubbingV1Project.)
+        this.assertDurationWithinPlan(planName, expectedDurationSec);
       }
 
       await this.throwIfCancelled(job.id!);
@@ -127,14 +151,25 @@ export class DubbingProcessor extends WorkerHost {
       await job.log('Cloning your voice and generating the dub...');
 
       // 2. Poll until it reports done.
-      await this.waitForElevenLabsDub(apiKey, dubbingId, job);
+      if (handle.kind === 'project') {
+        await this.waitForDubbingV1Project(apiKey, handle, job, planName);
+      } else {
+        await this.waitForElevenLabsDub(apiKey, handle.dubbingId, job);
+      }
       await job.updateProgress(70);
 
       // 3. Stream the result straight into the signed GCS PUT URL — piped, never
-      //    buffered, so a large MP4 stays off the heap.
+      //    buffered, so a large MP4 stays off the heap. (The project API hands back a
+      //    bare audio track instead, which has to be assembled on disk first.)
       await this.throwIfCancelled(job.id!);
       await job.log('Storing the dubbed file...');
-      await this.streamDubToGcs(apiKey, dubbingId, targetLanguage, outputPutUrl, outputContentType);
+      if (handle.kind === 'project') {
+        await this.storeDubbingV1Output(apiKey, handle, {
+          inputUrl, isVideo, putUrl: outputPutUrl, contentType: outputContentType,
+        });
+      } else {
+        await this.streamDubToGcs(apiKey, handle.dubbingId, targetLanguage, outputPutUrl, outputContentType);
+      }
       await job.updateProgress(80);
 
       // The result is now in GCS at the pre-signed location.
@@ -234,6 +269,188 @@ export class DubbingProcessor extends WorkerHost {
       dubbingId: data.dubbing_id,
       expectedDurationSec: typeof data.expected_duration_sec === 'number' ? data.expected_duration_sec : null,
     };
+  }
+
+  /** The vendor's own reading of the clip length — the first one we can trust. */
+  private assertDurationWithinPlan(planName: string | null | undefined, seconds: number | null): void {
+    if (!seconds || isDubDurationAllowed(planName, seconds)) return;
+    throw new Error(
+      `This clip is ${Math.round(seconds)}s, over the ${maxDubSecondsForPlan(planName)}s limit on your plan.`,
+    );
+  }
+
+  /**
+   * Start a dub on the project API, pinned to dubbing_v1 — the only model that covers
+   * the languages in DUBBING_V1_LANGUAGES. Passing `target_language` at create time
+   * queues the language target with it, so this is still one call rather than two.
+   *
+   * No accent: dubbing_v1 takes no equivalent of `target_accent`, which is why
+   * languages routed here deliberately offer no accents in the UI.
+   */
+  private async createDubbingV1Project(
+    apiKey: string,
+    sourceUrl: string,
+    targetLanguage: string,
+  ): Promise<Extract<DubHandle, { kind: 'project' }>> {
+    const form = new FormData();
+    form.append('source_url', sourceUrl);
+    form.append('target_language', targetLanguage);
+    form.append('model_id', 'dubbing_v1');
+
+    const response = await fetch(`${ELEVENLABS_API}/dubbing/project`, {
+      method: 'POST',
+      headers: { 'xi-api-key': apiKey },
+      body: form,
+      signal: AbortSignal.timeout(ELEVENLABS_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      if (response.status === 403 && /voice/i.test(detail)) {
+        throw new Error('Dubbing is temporarily unavailable — our voice capacity is full. Please try again later.');
+      }
+      throw new Error(`ElevenLabs dubbing failed (${response.status}): ${detail.slice(0, 400)}`);
+    }
+
+    const data = (await response.json()) as { project_id?: string; language_ids?: string[] };
+    const languageId = data.language_ids?.[0];
+    if (!data.project_id || !languageId) throw new Error('ElevenLabs did not return a dubbing project');
+
+    return { kind: 'project', projectId: data.project_id, languageId };
+  }
+
+  /**
+   * Follow a project dub to completion. Two resources move in sequence: the project
+   * transcribes (`ready`), then the language target renders (`completed`). One loop
+   * against one deadline covers both, so a stall anywhere still frees the slot.
+   */
+  private async waitForDubbingV1Project(
+    apiKey: string,
+    handle: Extract<DubHandle, { kind: 'project' }>,
+    job: Job<DubJobData>,
+    planName?: string | null,
+  ): Promise<void> {
+    const base = `${ELEVENLABS_API}/dubbing/project/${handle.projectId}`;
+    const deadline = Date.now() + ELEVENLABS_TIMEOUT_MS;
+    let durationChecked = false;
+
+    while (Date.now() < deadline) {
+      await this.throwIfCancelled(job.id!);
+
+      const project = await this.getElevenLabsJson<{
+        status?: string;
+        media?: { duration_s?: number | null } | null;
+        error?: { message?: string } | null;
+      }>(base, apiKey);
+
+      if (project.status === 'failed') {
+        throw new Error(`Dubbing failed: ${project.error?.message ?? 'ElevenLabs did not say why'}`);
+      }
+
+      // Available as soon as the source has been probed, which is before any
+      // synthesis runs — the same "check it early" window the legacy path gets.
+      if (!durationChecked && project.media?.duration_s) {
+        this.assertDurationWithinPlan(planName, project.media.duration_s);
+        durationChecked = true;
+      }
+
+      if (project.status === 'ready') {
+        const language = await this.getElevenLabsJson<{ status?: string; error?: { message?: string } | null }>(
+          `${base}/language/${handle.languageId}`,
+          apiKey,
+        );
+        if (language.status === 'completed') return;
+        if (language.status === 'failed') {
+          throw new Error(`Dubbing failed: ${language.error?.message ?? 'ElevenLabs did not say why'}`);
+        }
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, ELEVENLABS_POLL_INTERVAL_MS));
+    }
+
+    throw new Error('Dubbing took too long and timed out. Please try a shorter clip.');
+  }
+
+  /**
+   * Assemble and store a project dub. dubbing_v1 only ever returns an audio track
+   * (`outputs.lossless_audio`, FLAC, on a signed URL good for about an hour), so the
+   * finished file is made here: muxed back over the source video, or transcoded to MP3
+   * for an audio-only dub. Either way the result must match the content type the PUT
+   * URL was signed for.
+   *
+   * ponytail: goes through /tmp because ffmpeg needs seekable inputs. The ceiling is
+   * worker disk — one upload's worth per job, two jobs at a time. If that ever bites,
+   * the fix is a streamed remux, not a bigger disk.
+   */
+  private async storeDubbingV1Output(
+    apiKey: string,
+    handle: Extract<DubHandle, { kind: 'project' }>,
+    target: { inputUrl: string; isVideo: boolean; putUrl: string; contentType: string },
+  ): Promise<void> {
+    const language = await this.getElevenLabsJson<{ outputs?: { lossless_audio?: string | null } | null }>(
+      `${ELEVENLABS_API}/dubbing/project/${handle.projectId}/language/${handle.languageId}`,
+      apiKey,
+    );
+    const audioUrl = language.outputs?.lossless_audio;
+    if (!audioUrl) throw new Error('ElevenLabs finished the dub but returned no audio track');
+
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'dub-'));
+    try {
+      const audioPath = path.join(dir, 'dubbed.flac');
+      await this.downloadToFile(audioUrl, audioPath);
+
+      let videoPath: string | undefined;
+      if (target.isVideo) {
+        videoPath = path.join(dir, 'source');
+        await this.downloadToFile(target.inputUrl, videoPath);
+      }
+
+      const outputPath = path.join(dir, target.isVideo ? 'dubbed.mp4' : 'dubbed.mp3');
+      await muxDubbedAudio({ audioPath, videoPath, outputPath });
+      await this.uploadFile(outputPath, target.putUrl, target.contentType);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => null);
+    }
+  }
+
+  /** GET + parse, with the vendor's error text kept on failure. */
+  private async getElevenLabsJson<T>(url: string, apiKey: string): Promise<T> {
+    const response = await fetch(url, {
+      headers: { 'xi-api-key': apiKey },
+      signal: AbortSignal.timeout(ELEVENLABS_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      throw new Error(`ElevenLabs status check failed (${response.status}): ${detail.slice(0, 300)}`);
+    }
+    return (await response.json()) as T;
+  }
+
+  /** Stream a URL to disk. Both callers are already-signed URLs, so no auth header. */
+  private async downloadToFile(url: string, destination: string): Promise<void> {
+    const response = await fetch(url, { signal: AbortSignal.timeout(ELEVENLABS_TIMEOUT_MS) });
+    if (!response.ok || !response.body) {
+      const detail = await response.text().catch(() => '');
+      throw new Error(`Could not download the dubbed file (${response.status}): ${detail.slice(0, 300)}`);
+    }
+    await pipeline(Readable.fromWeb(response.body as any), createWriteStream(destination));
+  }
+
+  /** PUT a local file into the pre-signed GCS URL, streamed rather than buffered. */
+  private async uploadFile(source: string, putUrl: string, contentType: string): Promise<void> {
+    const { size } = await fs.stat(source);
+    const upload = await fetch(putUrl, {
+      method: 'PUT',
+      headers: { 'Content-Type': contentType, 'Content-Length': String(size) },
+      body: Readable.toWeb(createReadStream(source)) as any,
+      duplex: 'half', // required by undici when the body is a stream
+      signal: AbortSignal.timeout(ELEVENLABS_TIMEOUT_MS),
+    } as RequestInit & { duplex: 'half' });
+
+    if (!upload.ok) {
+      const detail = await upload.text().catch(() => '');
+      throw new Error(`Failed to store the dubbed file (${upload.status}): ${detail.slice(0, 300)}`);
+    }
   }
 
   /** Poll until the dub reports `dubbed`. Bounded so a stuck job cannot pin a slot. */

--- a/packages/workers/src/processor/utils/ffmpeg.ts
+++ b/packages/workers/src/processor/utils/ffmpeg.ts
@@ -1,0 +1,68 @@
+import { promisify } from 'util';
+import { execFile } from 'child_process';
+
+const execFileAsync = promisify(execFile);
+
+// A dub is at most one upload's worth of media; a remux that has not finished in this
+// long is stuck, not slow.
+const FFMPEG_TIMEOUT_MS = 10 * 60 * 1000;
+
+// Where ffmpeg comes from: an explicit override first, otherwise whatever is on PATH —
+// the worker image installs it (Dockerfile.worker), and FFMPEG_PATH covers the dev
+// machines that have it somewhere else. Same env var the API's ffmpeg-config.ts reads.
+const FFMPEG_CANDIDATES = [process.env.FFMPEG_PATH, 'ffmpeg'].filter(Boolean) as string[];
+let resolvedFfmpeg: string | null = null;
+
+/**
+ * Lay a dubbed audio track over the original media.
+ *
+ * With `videoPath`, the picture is copied through untouched (no re-encode, so cost is
+ * IO not CPU) and only the new audio is written. Without one, the track is transcoded
+ * to MP3 — both because the dubbed track arrives as FLAC and because the signed GCS PUT
+ * URL for an audio dub is bound to `audio/mpeg`.
+ *
+ * ffmpeg comes from the worker image (see Dockerfile.worker).
+ */
+export async function muxDubbedAudio({
+  audioPath,
+  videoPath,
+  outputPath,
+}: {
+  audioPath: string;
+  videoPath?: string;
+  outputPath: string;
+}): Promise<void> {
+  const args = videoPath
+    ? ['-y', '-i', videoPath, '-i', audioPath,
+       '-map', '0:v:0', '-map', '1:a:0',
+       '-c:v', 'copy', '-c:a', 'aac', '-b:a', '192k',
+       '-shortest', outputPath]
+    : ['-y', '-i', audioPath, '-c:a', 'libmp3lame', '-q:a', '2', outputPath];
+
+  await runFfmpeg(args);
+}
+
+/** Run ffmpeg from the first candidate that exists, remembering which one worked. */
+async function runFfmpeg(args: string[]): Promise<void> {
+  const candidates = resolvedFfmpeg ? [resolvedFfmpeg] : FFMPEG_CANDIDATES;
+
+  for (const [index, binary] of candidates.entries()) {
+    try {
+      await execFileAsync(binary, args, { timeout: FFMPEG_TIMEOUT_MS, maxBuffer: 10 * 1024 * 1024 });
+      resolvedFfmpeg = binary;
+      return;
+    } catch (error: any) {
+      // Not installed under that name — try the next one before giving up.
+      if (error?.code === 'ENOENT' && index < candidates.length - 1) continue;
+      if (error?.code === 'ENOENT') {
+        throw new Error(
+          `ffmpeg is not installed (tried ${candidates.join(', ')}). Dubs into languages that ` +
+          'run on the dubbing_v1 model are assembled locally and need it — set FFMPEG_PATH or install ffmpeg.',
+        );
+      }
+      // ffmpeg says what went wrong on the last lines of stderr; the rest is banner noise.
+      const detail = String(error?.stderr || error?.message || '').trim().slice(-400);
+      throw new Error(`ffmpeg failed while assembling the dub: ${detail}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- The default `/v1/dubbing` endpoint (dubbing_v2, what every other language uses) hard-rejects Bengali and tops out at 32 languages. Bengali now routes through the project API pinned to `model_id=dubbing_v1`, which covers Eleven v3's ~85 languages — mechanism is generic, so adding another v1-only language later is two lines (`DUBBING_V1_LANGUAGES` in `packages/validations/src/consts/dubbing.ts`).
- Every existing language is untouched: same endpoint, same `target_accent` picker, same server-rendered MP4.
- `dubbing_v1` returns audio only, so the worker assembles the final file: mux over the source video (stream-copy picture, re-encode audio) or transcode to MP3 for audio-only dubs, via a new ffmpeg helper. No new dependency — the worker image already installs ffmpeg (`Dockerfile.worker`); the helper resolves it from `FFMPEG_PATH` or `PATH`.
- `targetLanguage` is now validated against the offered list server-side (it now picks the backend, so an unrecognized code must not reach the worker), and the language picker clears any selected accent on change (Bengali/v1 offers none).

## Test plan
- [x] `npx tsx packages/validations/src/consts/dubbing.check.ts` — self-check passes, including the new v1-routing/accent-consistency assertions
- [x] `apps/api` dubbing test suite (19 tests) passes unchanged
- [x] `workers` / `api` / `web` all typecheck
- [x] Live Bengali dub run against the real ElevenLabs API end to end (project create → poll → FLAC download)
- [x] Both ffmpeg invocations (video mux, audio transcode) verified inside the actual `node:20-alpine` + ffmpeg worker image
- [ ] Full worker job (Redis + GCS) for a Bengali video dub on staging — not run here, recommend before telling the client