### PR TITLE
chore(domain): move the app, emails and AEO surface to trycreatorai.com

### DIFF
--- a/.claude/skills/blog-post-seo/SKILL.md
+++ b/.claude/skills/blog-post-seo/SKILL.md
@@ -46,7 +46,7 @@ phrase the post ranks for and the thing every check below measures.
 8. Keyword **density ≥ 0.90%** AND the `focusKeyword` appears **≥ 7 times**,
    placed naturally (intro, a subheading, body, a FAQ, conclusion). Do NOT stuff —
    if 7 reads unnatural, the focus keyword is too narrow; broaden it.
-9. **URL ≥ 70 chars** (`https://tryscriptai.com/blog/<slug>`). Only applies to NEW
+9. **URL ≥ 70 chars** (`https://trycreatorai.com/blog/<slug>`). Only applies to NEW
    posts — never rename a published slug without a 301 redirect (breaks rankings).
 10. Link out to ≥ 1 **external** authority (YouTube docs, research, news) with a
     real dofollow `[text](https://…)` — our markdown renders external links as

--- a/.env.example
+++ b/.env.example
@@ -76,4 +76,4 @@ LEMONSQUEEZY_WEBHOOK_SECRET=your-lemonsqueezy-webhook-secret
 NEXT_PUBLIC_BACKEND_URL=http://localhost:8000
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 FRONTEND_DEV_URL=http://localhost:3000
-FRONTEND_PROD_URL=https://tryscriptai.com
+FRONTEND_PROD_URL=https://trycreatorai.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **MINOR** – new features, non-breaking enhancements.
 - **PATCH** – backwards-compatible bug fixes, perf, docs, chores.
 
-The canonical version lives in the root [`package.json`](./package.json) and is mirrored in `apps/web` and `apps/api`. Every release gets a tag `vX.Y.Z` and a GitHub Release. The public-facing changelog page ([/changelog](https://tryscriptai.com/changelog)) is sourced from `apps/web/lib/changelog-data.ts` — keep it in sync with this file.
+The canonical version lives in the root [`package.json`](./package.json) and is mirrored in `apps/web` and `apps/api`. Every release gets a tag `vX.Y.Z` and a GitHub Release. The public-facing changelog page ([/changelog](https://trycreatorai.com/changelog)) is sourced from `apps/web/lib/changelog-data.ts` — keep it in sync with this file.
 
 How to cut a release:
 
@@ -29,6 +29,33 @@ How to cut a release:
 
 ### Added
 - Placeholder for upcoming features.
+
+---
+
+## [1.5.0] – 2026-08-23
+
+The blog stops being a TypeScript file and becomes a real CMS: posts live in the database, are written in the admin dashboard against a live SEO audit, and can be scheduled. The product also moves to its own domain, trycreatorai.com.
+
+### Added
+- **Blog CMS** — `blog_posts` carries the full content model (SEO title/description, focus keyword, supporting keywords, FAQs, videos, read time, author), with every rule of the SEO checklist enforced as a CHECK constraint on publish. The 44 live posts were seeded out of `lib/blog-data.ts`.
+- **One blog editor** for create and edit, covering all 18 fields plus repeatable FAQ and video rows, with a live SEO panel running the same `auditPost` rules as `pnpm seo:audit` and a publish-blocker summary before saving.
+- **Post scheduling** — `published_at` is settable directly, so posts can be backdated or dated forward; a future date holds the post out of the live blog, sitemap, and feeds until then. The admin list shows a scheduled badge, focus keyword, and SEO pass/gap state.
+- **Named author byline** — posts are bylined from `lib/authors.ts` with an avatar, role, bio, and socials, and the page emits `Person` author schema with `sameAs` instead of a faceless Organization.
+- **Rotating quote footer** on the dashboard, picked client-side so it can't trip a hydration mismatch.
+- Blog coverage grew with comparison, alternatives, and workflow posts, plus a YouTube-algorithm category.
+
+### Changed
+- **Domain migration** — tryscriptai.com → trycreatorai.com across the app, emails, Caddy, docs, and `llms.txt`; the X handle becomes `@joincreatorai`. Seeded database rows that the code can't reach (sender pool, email template HTML, self-linking post content) move in an idempotent migration, since email clients don't follow a 301 for a logo image.
+- **Public blog reads from the database** via `lib/blog-source.ts` — the anon key plus the published-only RLS policy keeps the pages statically renderable.
+- **Blog consolidation, 55 posts to 44** — cannibalising clusters merged into hubs with 301s and no redirect chains, head terms retargeted to winnable ones, first-party pricing and performance data added, and publish dates respaced from same-day clusters to 1–2 per week.
+- The SEO audit now flags em dashes and over-length meta descriptions.
+
+### Fixed
+- **Dubs failed after ElevenLabs had already run.** The precheck only covered one second of audio, and a stale `DUBBING_CREDIT_MULTIPLIER=15` in `.env.example` overrode the code default of 3, billing 5×. Cost is now checked for the full duration up front and reported with real numbers.
+- **Every admin blog list load 400'd** on a PostgREST embed naming a constraint that leads to `auth.users`, which isn't exposed for embedding. The byline now comes from `blog_posts.author_name`.
+- **Mass assignment on blog create/update** — request bodies were spread straight into the Supabase write, letting an admin set `id`, `author_id`, or `created_at`. Both paths now go through a writable-field whitelist.
+- Blog post pages each emitted the whole blog's schema instead of their own.
+- `author_id` was `NOT NULL ... ON DELETE CASCADE`, so deleting one admin account would have deleted the entire blog. Now nullable, `ON DELETE SET NULL`.
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-support@tryscriptai.com.
+support@trycreatorai.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -115,7 +115,7 @@ the community.
 ## Reporting Guidelines
 
 If you experience or witness unacceptable behavior—or have any other concerns—
-please report it by contacting the community team at support@tryscriptai.com.
+please report it by contacting the community team at support@trycreatorai.com.
 All reports will be handled with discretion. In your report please include:
 
 * Your contact information.
@@ -161,7 +161,7 @@ https://www.contributor-covenant.org/translations.
 For questions or concerns about this Code of Conduct, please contact us:
 
 - **Discord**: [Join our community](https://discord.gg/k9sZcq2gNG)
-- **Reach out to us at**: support@tryscriptai.com
+- **Reach out to us at**: support@trycreatorai.com
 - **GitHub Issues**: [Create an issue](https://github.com/scriptaiapp/scriptai/issues)
 
 ## License and Attribution

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,7 +1,21 @@
-tryscriptai.com, www.tryscriptai.com {
+trycreatorai.com, www.trycreatorai.com {
 	reverse_proxy web:3000
 }
 
+# Old domain: kept for a year so existing links, email logos and search results
+# keep resolving. 301 preserves path and query, so /blog/x?ref=y lands on the
+# same page on the new domain and passes the ranking signal across.
+tryscriptai.com, www.tryscriptai.com {
+	redir https://trycreatorai.com{uri} permanent
+}
+
+api.trycreatorai.com {
+	reverse_proxy api:8000
+}
+
+# The old API host is proxied, not redirected: a browser drops the body of a
+# POST across a 301 and blocks credentialed CORS requests that redirect, so any
+# still-cached bundle pointing here would break. It serves the same API instead.
 api.tryscriptai.com {
 	reverse_proxy api:8000
 }

--- a/README.md
+++ b/README.md
@@ -1,30 +1,35 @@
 # Creator AI
 
-> **AI that learns your style and helps you create content faster.** Creator AI analyzes your existing YouTube videos to understand your tone, vocabulary, and structure — then generates scripts, subtitles, ideas, stories, and more — all personalized to you.
+> **AI that learns your style and helps you create content faster.** Creator AI analyzes your existing YouTube videos to understand your tone, vocabulary, and structure — then generates scripts, subtitles, ideas, thumbnails, dubs, and videos — all personalized to you.
 
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-7289DA?style=for-the-badge&logo=discord)](https://discord.com/invite/k9sZcq2gNG)
-[![GitHub Stars](https://img.shields.io/github/stars/scriptaiapp/scriptai?style=for-the-badge)](https://github.com/scriptaiapp/scriptai/stargazers)
+[![GitHub Stars](https://img.shields.io/github/stars/creatorai-app/creatorai?style=for-the-badge)](https://github.com/creatorai-app/creatorai/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
+
+[trycreatorai.com](https://trycreatorai.com) · [Changelog](https://trycreatorai.com/changelog) · [Blog](https://trycreatorai.com/blog)
 
 ## Features
 
-- **AI Style Training** — Connect YouTube, provide 3–5 videos, and the AI learns your unique tone, vocabulary, and pacing
+- **AI Style Training** — Connect YouTube, provide 3–5 videos, and the AI watches them to learn your tone, vocabulary, and pacing
 - **Script Generation** — Personalized video scripts via BullMQ worker; supports file attachments, storytelling mode, timestamps, multi-language output, and PDF export
-- **Ideation** — AI-powered idea generation with live web search, trend snapshots, opportunity scoring, content angles, and sources; export as PDF/JSON
+- **Ideation** — AI-powered idea generation with live web search, trend snapshots, opportunity scoring, content angles, and sources; **Surprise me** picks a niche focus from your trained style; export as PDF/JSON
 - **Story Builder** — Structured narrative generation from a topic with real-time SSE progress
-- **Subtitle Generation** — Upload video (max 200 MB / 10 min), auto-generate timed subtitles, translate, edit in-app, export as SRT/VTT, burn into video via FFmpeg
-- **Audio/Video Dubbing** — Dub media into 24+ languages via Murf.ai with real-time progress
-- **Billing & Subscriptions** — Stripe-powered checkout, customer portal, webhook handling, and plan management
-- **Credit System** — Token-based credits consumed per AI operation, tracked automatically
-- **Referral Program** — Unique referral codes, track referrals, earn bonus credits
+- **Subtitle Generation** — Direct-to-GCS uploads (100 MB / 10 min on Starter, 2 GB / 45 min on paid plans), timed subtitles, translation, in-app editing, SRT/VTT export, and burn-in via FFmpeg
+- **AI Dubbing** — Dub audio or video into 29 languages in the creator's own cloned voice; browser uploads straight to GCS, BullMQ-queued with SSE progress, cancellation, and regeneration
+- **AI Video Generation** — Text-to-video, image-to-video, reference-to-video, and stateful editing via Gemini Omni Flash; async worker with cancellation and a history page
+- **Thumbnail Generation** — AI thumbnails from a prompt or reference image, billed per image
+- **Hannah** — Gemini-powered guide chatbot; anonymous and rate-limited on the marketing site, plan- and credit-aware inside the dashboard
+- **Channel Stats** — Subscriber, view, and video counts on onboarding and connected-channel cards, with plan-based sync limits
+- **Billing & Subscriptions** — Lemon Squeezy checkout, customer portal, signed webhooks, admin plan grants, and expiry reminders
+- **Credit System** — Token-based credits consumed per AI operation, with the full cost prechecked before any paid vendor call
+- **Referrals & Affiliates** — Referral codes for bonus credits, plus an affiliate program with commission tracking and payouts
+- **Admin Dashboard** — Users, subscriptions, activity feed, error logs, job monitoring, promo codes, bulk email campaigns, affiliate management, and a blog CMS with a live SEO audit and post scheduling
 - **Auth** — Email/password and Google OAuth, OTP-based password reset, email verification via Supabase Auth
 - **Profile & Settings** — Avatar upload, notification preferences, billing info
 
 ### Coming Soon
 
-- **Thumbnail Generator** — AI-generated thumbnail descriptions (backend ready)
 - **Course Module Builder** — Structured course outlines from a topic (backend ready)
-- **AI Video Generator** — Page placeholder at `/dashboard/video-generation`
 
 ## Tech Stack
 
@@ -34,11 +39,11 @@
 | Backend | NestJS, TypeScript, Zod validation |
 | Database | Supabase (PostgreSQL), Row-Level Security |
 | Auth | Supabase Auth (JWT), Google OAuth |
-| AI | Google Gemini 3.5 Flash on Vertex AI, OpenAI GPT-4o |
-| Payments | Stripe (Checkout, Billing Portal, Webhooks) |
-| Dubbing | Murf.ai |
-| Jobs | BullMQ + Redis (train-ai, script, ideation, story-builder queues) |
-| Media | FFmpeg, Supabase Storage |
+| AI | Gemini on Vertex AI — `gemini-3.6-flash` (text), `gemini-3.5-flash-lite`, `gemini-3.1-flash-image` (thumbnails), `gemini-omni-flash-preview` (video), `gemini-embedding-001` |
+| Payments | Lemon Squeezy (checkout, portal, webhooks) |
+| Dubbing | ElevenLabs (voice cloning + dubbing), Modal serverless GPU |
+| Jobs | BullMQ + Redis (train-ai, script, ideation, story-builder, thumbnail, dubbing, video-generation, email-campaign) |
+| Media | FFmpeg, Google Cloud Storage, Supabase Storage |
 | Email | Resend |
 | Monorepo | Turborepo + pnpm workspaces |
 
@@ -49,6 +54,7 @@ creatorai/
 ├── apps/
 │   ├── web/                          # Next.js 15 frontend
 │   │   ├── app/
+│   │   │   ├── blog/                 # Public blog, rendered from the database
 │   │   │   ├── dashboard/
 │   │   │   │   ├── train/            # AI style training
 │   │   │   │   ├── scripts/          # Script generation & editing
@@ -56,43 +62,53 @@ creatorai/
 │   │   │   │   ├── story-builder/    # Narrative structure builder
 │   │   │   │   ├── subtitles/        # Subtitle generation & editing
 │   │   │   │   ├── dubbing/          # Audio/video dubbing
-│   │   │   │   ├── thumbnails/       # Thumbnail generator (coming soon)
+│   │   │   │   ├── video-generation/ # AI video generation
+│   │   │   │   ├── thumbnails/       # Thumbnail generation
 │   │   │   │   ├── courses/          # Course builder (coming soon)
-│   │   │   │   ├── video-generation/ # Video generator (coming soon)
-│   │   │   │   ├── settings/         # User settings & billing
-│   │   │   │   └── referrals/        # Referral program
+│   │   │   │   ├── admin/            # Admin: users, blogs, emails, errors, jobs…
+│   │   │   │   ├── affiliate/        # Affiliate program
+│   │   │   │   ├── referrals/        # Referral program
+│   │   │   │   └── settings/         # User settings & billing
 │   │   │   └── api/                  # Next.js API routes
 │   │   ├── components/               # React components
 │   │   ├── hooks/                    # Custom React hooks
-│   │   └── lib/                      # Utilities & API helpers
+│   │   ├── lib/                      # Utilities, blog source & shared SEO rules
+│   │   └── scripts/                  # seo:audit, llms:generate
 │   └── api/                          # NestJS backend
 │       └── src/
 │           ├── auth/                 # Password reset (OTP flow)
-│           ├── billing/              # Stripe checkout, portal, webhooks
+│           ├── billing/              # Lemon Squeezy checkout, portal, webhooks
 │           ├── ideation/             # AI idea generation (BullMQ)
 │           ├── script/               # Script generation (BullMQ)
 │           ├── story-builder/        # Story structure generation (BullMQ)
 │           ├── subtitle/             # Subtitle CRUD + burn (FFmpeg)
-│           ├── dubbing/              # Dubbing via Murf.ai
-│           ├── train-ai/             # AI training job queue
+│           ├── dubbing/              # Dubbing (ElevenLabs + Modal)
+│           ├── video-generation/     # AI video generation (BullMQ)
 │           ├── thumbnail/            # Thumbnail generation
+│           ├── train-ai/             # AI training job queue
+│           ├── hannah/               # Guide chatbot
+│           ├── channel-stats/        # YouTube channel metrics
 │           ├── course/               # Course module builder
+│           ├── admin/                # Admin APIs incl. blog CMS
+│           ├── affiliate/            # Affiliate program
 │           ├── referral/             # Referral system
+│           ├── email-campaign/       # Bulk email campaigns
 │           ├── youtube/              # YouTube OAuth & channel data
 │           ├── upload/               # File uploads
 │           ├── support/              # Issue reporting
 │           └── supabase/             # Supabase client module
 ├── packages/
-│   ├── validations/                  # Shared Zod schemas, types & credit utils
+│   ├── validations/                  # Shared Zod schemas, types, model & credit consts
 │   ├── supabase/                     # Supabase migrations & client utilities
-│   ├── workers/                      # BullMQ workers (train-ai, script, ideation, story-builder)
-│   ├── email-templates/              # Email templates (OTP, welcome)
+│   ├── workers/                      # BullMQ workers + subscription reminders
+│   ├── email-templates/              # Email templates & merge tags
 │   ├── config/                       # Shared constants
 │   ├── ui/                           # Shared UI components
 │   └── api/                          # Shared API types
-├── docs/
-│   └── SETUP.md                      # Detailed development setup guide
-├── docker-compose.yml                # Redis + worker services
+├── modal/                            # Modal serverless-GPU dubbing service (Python)
+├── docs/                             # Setup, hosting & design docs
+├── docker-compose.yml                # Redis + worker services (dev)
+├── docker-compose.prod.yml           # Redis + api + worker + web + Caddy (prod)
 └── turbo.json                        # Turborepo pipeline config
 ```
 
@@ -108,8 +124,8 @@ creatorai/
 ### 1. Clone & Install
 
 ```bash
-git clone https://github.com/scriptaiapp/scriptai.git
-cd scriptai
+git clone https://github.com/creatorai-app/creatorai.git
+cd creatorai
 pnpm install
 ```
 
@@ -126,14 +142,13 @@ pnpx supabase db push --db-url <your-supabase-db-url>
 
 ### 3. Configure Environment
 
+The root `.env` is the single source of truth — the API, the workers, and the web app all read from it.
+
 ```bash
 cp .env.example .env
-cp apps/web/.env.example apps/web/.env
-cp apps/api/.env.example apps/api/.env
-cp packages/workers/.env.example packages/workers/.env
 ```
 
-Edit each `.env` file with your credentials. See the `.env.example` files for required keys.
+Fill it in with your credentials. See [`.env.example`](./.env.example) for every key and which service reads it.
 
 <details>
 <summary>Required services & API keys</summary>
@@ -141,14 +156,14 @@ Edit each `.env` file with your credentials. See the `.env.example` files for re
 | Service | Key | Required | Purpose |
 |---------|-----|----------|---------|
 | Supabase | `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_KEY` | Yes | Database, auth, storage |
-| Google Vertex AI (Gemini) | `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, ADC (`GOOGLE_APPLICATION_CREDENTIALS`) | Yes | Script generation, ideation, training, transcription, thumbnails |
+| Google Vertex AI (Gemini) | `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, ADC (`GOOGLE_APPLICATION_CREDENTIALS`) | Yes | Scripts, ideation, training, subtitles, thumbnails, video |
 | Redis | `REDIS_URL` | Yes | BullMQ job queues (api + worker) |
-| OpenAI | `OPENAI_API_KEY` | Optional | Subtitle generation |
-| Resend | `RESEND_API_KEY` | Optional | Transactional emails |
+| Google Cloud Storage | `GCS_SUBTITLE_BUCKET`, `GCS_VIDEO_BUCKET`, `GCS_DUBBING_BUCKET` | Yes | Direct media uploads, read by Vertex from `gs://` |
+| Modal | `MODAL_API_URL` | Optional | Serverless-GPU dubbing service |
+| Resend | `RESEND_API_KEY` | Optional | Transactional emails & campaigns |
 | YouTube | `YOUTUBE_API_KEY` | Optional | Channel integration |
 | Google OAuth | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` | Optional | YouTube OAuth |
-| Murf.ai | `MURF_API_KEY` | Optional | Audio/video dubbing |
-| Stripe | via billing module config | Optional | Payments & subscriptions |
+| Lemon Squeezy | `LEMONSQUEEZY_API_KEY`, `LEMONSQUEEZY_STORE_ID`, `LEMONSQUEEZY_WEBHOOK_SECRET` | Optional | Payments & subscriptions |
 
 </details>
 
@@ -180,9 +195,13 @@ pnpm run dev --filter=api     # Backend only  — http://localhost:8000
 | `pnpm run dev --filter=api` | Start backend only |
 | `pnpm run build` | Build all packages and apps |
 | `pnpm run test` | Run tests |
+| `pnpm run test:e2e` | Run Playwright end-to-end tests |
 | `pnpm run lint` | Lint all code |
 | `pnpm run type-check` | TypeScript type checking |
 | `pnpm run format` | Format with Prettier |
+| `pnpm run release <version>` | Bump versions in lockstep after the changelog entry is authored |
+| `pnpm --filter web seo:audit` | Audit every published blog post against the SEO checklist |
+| `pnpm --filter web llms:generate` | Regenerate `llms.txt` / `llms-full.txt` |
 
 ## Architecture Overview
 
@@ -190,17 +209,22 @@ pnpm run dev --filter=api     # Backend only  — http://localhost:8000
 ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
 │   Next.js    │────▶│   NestJS     │────▶│  Supabase    │
 │   Frontend   │     │   Backend    │     │  (Postgres)  │
-└──────────────┘     └──────┬───────┘     └──────────────┘
-                            │
-                     ┌──────▼───────┐     ┌──────────────┐
-                     │   BullMQ     │────▶│  AI Workers   │
-                     │   (Redis)    │     │  (Gemini/GPT) │
-                     └──────────────┘     └──────────────┘
+└──────┬───────┘     └──────┬───────┘     └──────────────┘
+       │                    │
+       │             ┌──────▼───────┐     ┌───────────────┐
+       │             │   BullMQ     │────▶│  AI Workers   │
+       │             │   (Redis)    │     │  (Vertex AI)  │
+       │             └──────────────┘     └──────┬────────┘
+       │                                         │
+       └────────────▶┌──────────────┐◀───────────┘
+       signed upload │     GCS      │  gs:// reads
+                     └──────────────┘
 ```
 
-- **Frontend** calls Next.js API routes for AI operations (scripts, ideation) and the NestJS backend for subtitles, dubbing, training, and billing.
-- **Backend** validates requests, manages auth, and enqueues long-running AI tasks to BullMQ.
-- **Workers** process queued jobs (training, script generation, ideation, story builder) with SSE progress streaming back to the client.
+- **Frontend** calls Next.js API routes for some AI operations and the NestJS backend for subtitles, dubbing, video generation, training, billing, and admin.
+- **Backend** validates requests, enforces plan and credit limits before any paid vendor call, and enqueues long-running work to BullMQ.
+- **Workers** process queued jobs (training, scripts, ideation, story builder, thumbnails, dubbing, video generation, email campaigns) with SSE progress streaming back to the client.
+- **Media** is uploaded from the browser straight to GCS via signed URLs, so the API never proxies the bytes and Vertex reads them from `gs://`.
 - **Supabase** handles auth, database (with RLS), and file storage.
 
 ## Documentation
@@ -209,9 +233,15 @@ pnpm run dev --filter=api     # Backend only  — http://localhost:8000
 |----------|-------------|
 | [Requirements](./requirements.md) | Full feature specification |
 | [Setup Guide](./docs/SETUP.md) | Detailed development environment setup |
+| [Vertex AI Setup](./docs/vertex-ai-setup.md) | Google Cloud project, ADC, and model access |
+| [Lemon Squeezy Pricing](./docs/lemonsqueezy-pricing-setup.md) | Plans, variants, and webhook wiring |
+| [Hosting Guide](./docs/aws-lightsail-hosting.md) | Production deploy on AWS Lightsail with Caddy |
+| [Dubbing Design](./docs/dubbing-design.md) | Dubbing pipeline architecture |
+| [Video Generation Design](./docs/video-generation-design.md) | Video pipeline architecture |
 | [API Docs](./apps/api/README.md) | Backend endpoints reference |
 | [Web App Docs](./apps/web/README.md) | Frontend pages & routes |
 | [Database Schema](./packages/supabase/README.md) | Supabase schema documentation |
+| [Changelog](./CHANGELOG.md) | Release history & versioning policy |
 | [Contributing Guide](./CONTRIBUTING.md) | How to contribute |
 | [Code of Conduct](./CODE_OF_CONDUCT.md) | Community guidelines |
 
@@ -225,7 +255,7 @@ pnpm run dev --filter=api     # Backend only  — http://localhost:8000
 ## Community
 
 - [Discord](https://discord.com/invite/k9sZcq2gNG) — Questions, discussions, and support
-- [GitHub Issues](https://github.com/scriptaiapp/scriptai/issues) — Bug reports and feature requests
+- [GitHub Issues](https://github.com/creatorai-app/creatorai/issues) — Bug reports and feature requests
 
 ## License
 

--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -901,9 +901,9 @@ export class AdminService {
     if (error || !mail) throw new NotFoundException('Mail not found');
 
     const { error: sendErr } = await this.resend.emails.send({
-      from: 'Creator AI <notifications@tryscriptai.com>',
+      from: 'Creator AI <notifications@trycreatorai.com>',
       to: mail.from_email,
-      replyTo: 'support@tryscriptai.com',
+      replyTo: 'support@trycreatorai.com',
       subject,
       html: `<div style="font-family: Arial, sans-serif; color: #333; line-height: 1.6;">${html}</div>`,
     });

--- a/apps/api/src/affiliate/affiliate.service.spec.ts
+++ b/apps/api/src/affiliate/affiliate.service.spec.ts
@@ -200,7 +200,7 @@ describe('AffiliateService', () => {
       );
       expect(sendMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          from: expect.stringContaining('support@tryscriptai.com'),
+          from: expect.stringContaining('support@trycreatorai.com'),
           to: 'applicant@test.com',
           subject: expect.stringContaining('approved'),
           html: expect.stringContaining('Welcome aboard!'),

--- a/apps/api/src/affiliate/affiliate.service.ts
+++ b/apps/api/src/affiliate/affiliate.service.ts
@@ -165,7 +165,7 @@ export class AffiliateService {
       (s ?? '—').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
     await this.resend.emails.send({
-      from: 'Creator AI <notifications@tryscriptai.com>',
+      from: 'Creator AI <notifications@trycreatorai.com>',
       to: this.adminEmail,
       subject: `New Affiliate Application from ${data.full_name}`,
       html: `<div style="font-family:Arial,sans-serif;color:#333;background:#f9f9f9;padding:20px">
@@ -276,9 +276,9 @@ export class AffiliateService {
 
     try {
       await this.resend.emails.send({
-        from: 'Creator AI Support <support@tryscriptai.com>',
+        from: 'Creator AI Support <support@trycreatorai.com>',
         to: input.recipientEmail,
-        replyTo: 'support@tryscriptai.com',
+        replyTo: 'support@trycreatorai.com',
         subject: 'Your affiliate application was approved',
         html: `<div style="font-family:Arial,sans-serif;color:#333;line-height:1.6;max-width:600px;margin:auto;padding:20px">
           <h2 style="color:#4F46E5;margin-top:0">You're approved as a Creator AI affiliate</h2>

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -44,7 +44,7 @@ export class AuthService implements OnModuleInit {
 
     try {
       await this.resend.emails.send({
-        from: 'Creator AI <no-reply@tryscriptai.com>',
+        from: 'Creator AI <no-reply@trycreatorai.com>',
         to: email,
         subject: 'Your Password Reset Code',
         html,

--- a/apps/api/src/hannah/hannah.knowledge.ts
+++ b/apps/api/src/hannah/hannah.knowledge.ts
@@ -30,7 +30,7 @@ PLANS & CREDITS:
 
 HELPFUL LINKS:
 - All features: /features · Pricing: /pricing · Blog & guides: /blog · Changelog: /changelog · About: /about-us · Contact / support: /contact-us
-- Support email: support@tryscriptai.com
+- Support email: support@trycreatorai.com
 `;
 
 export function buildHannahSystemPrompt(context: 'public' | 'dashboard'): string {
@@ -46,7 +46,7 @@ Personality: warm, upbeat, concise, and genuinely helpful. You talk like a knowl
 ${placement}
 
 How you answer:
-- Answer ONLY from the knowledge below plus general YouTube/content-creation know-how. If you don't know or it's outside Creator AI, say so briefly and point to /contact-us or support@tryscriptai.com.
+- Answer ONLY from the knowledge below plus general YouTube/content-creation know-how. If you don't know or it's outside Creator AI, say so briefly and point to /contact-us or support@trycreatorai.com.
 - Be concise, short and direct — but informative. Lead with the answer in the first sentence; add only what the user actually needs. 1–3 short sentences, or a tight numbered list for how-tos. Never pad, never restate the question, no walls of text.
 - ALWAYS include the relevant reference link(s) as Markdown links, e.g. [Script Writing](/dashboard/scripts). Turn the "Open:" / "Learn more:" / "See:" paths below into Markdown links.
 - Never invent features, prices, or links that aren't below. Never claim to perform actions for the user — you guide, the tools do the work.

--- a/apps/api/src/support/support.service.ts
+++ b/apps/api/src/support/support.service.ts
@@ -44,8 +44,8 @@ export class SupportService {
     const safeBody = escapeHtml(body);
 
     const { data, error } = await this.resend.emails.send({
-      from: 'Creator AI <notifications@tryscriptai.com>',
-      to: 'support@tryscriptai.com',
+      from: 'Creator AI <notifications@trycreatorai.com>',
+      to: 'support@trycreatorai.com',
       replyTo: email,
       subject,
       html: `<div style="font-family: Arial, sans-serif; color: #333; background: #f9f9f9; padding: 20px;">

--- a/apps/web/app/about-us/page.tsx
+++ b/apps/web/app/about-us/page.tsx
@@ -147,8 +147,8 @@ export default function AboutPage() {
                 <p>
                   <strong className="text-slate-800">Creator AI</strong> is an AI-powered production
                   platform for YouTube creators, available at{" "}
-                  <a href="https://tryscriptai.com" className="text-purple-600 hover:text-purple-700">
-                    tryscriptai.com
+                  <a href="https://trycreatorai.com" className="text-purple-600 hover:text-purple-700">
+                    trycreatorai.com
                   </a>
                   . Founded to solve the gap between generic AI tools and YouTube-specific content
                   creation, Creator AI learns each creator&apos;s unique voice from their existing
@@ -169,7 +169,7 @@ export default function AboutPage() {
                 </div>
                 <div>
                   <dt className="font-semibold text-slate-800 mb-1">Website</dt>
-                  <dd className="text-slate-600">tryscriptai.com</dd>
+                  <dd className="text-slate-600">trycreatorai.com</dd>
                 </div>
                 <div>
                   <dt className="font-semibold text-slate-800 mb-1">Core capability</dt>

--- a/apps/web/app/affiliate-terms/page.tsx
+++ b/apps/web/app/affiliate-terms/page.tsx
@@ -69,9 +69,9 @@ const AffiliateTermsPage = () => (
     <PolicySection id="tracking" title="3. Links, Promo Codes & Attribution">
       <p>
         You can promote Creator AI in two ways: a tracking link
-        (<code>tryscriptai.com/?ref=YOURCODE</code>) that you generate yourself, and a promo
+        (<code>trycreatorai.com/?ref=YOURCODE</code>) that you generate yourself, and a promo
         code issued to you by our team, which gives your audience a discount and is shared
-        as a code or as a link (<code>tryscriptai.com/?promo=YOURCODE</code>).
+        as a code or as a link (<code>trycreatorai.com/?promo=YOURCODE</code>).
       </p>
       <p>
         Both are stored in the visitor&apos;s browser for <strong>30 days</strong> from the
@@ -281,8 +281,8 @@ const AffiliateTermsPage = () => (
     <PolicySection id="contact" title="14. Contact">
       <p>
         Questions about the program, a payout, or a promo code? Email us at{" "}
-        <Link href="mailto:support@tryscriptai.com" className={linkClass}>
-          support@tryscriptai.com
+        <Link href="mailto:support@trycreatorai.com" className={linkClass}>
+          support@trycreatorai.com
         </Link>{" "}
         or use our{" "}
         <Link href="/contact-us" className={linkClass}>

--- a/apps/web/app/api/auth/callback/route.ts
+++ b/apps/web/app/api/auth/callback/route.ts
@@ -24,10 +24,10 @@ async function sendWelcomeEmail(
   if (!resend) return;
   try {
     await resend.emails.send({
-      from: 'Creator AI <onboarding@tryscriptai.com>',
+      from: 'Creator AI <onboarding@trycreatorai.com>',
       to: email,
       subject: 'Welcome to Creator AI!',
-      replyTo: 'support@tryscriptai.com',
+      replyTo: 'support@trycreatorai.com',
       html: `
         <div style="font-family: Arial, sans-serif; color: #333; line-height: 1.6; max-width: 600px; margin: auto; padding: 20px;">
           <h1 style="color: #4F46E5; margin-bottom: 10px;">Welcome aboard, ${escapeHtml(full_name)}! 🎉</h1>
@@ -35,13 +35,13 @@ async function sendWelcomeEmail(
           <p>We're excited to have you join <strong>Creator AI</strong>. 🚀</p>
           <p>
             Open your dashboard:
-            <a href="https://tryscriptai.com/dashboard" style="color: #4F46E5; text-decoration: none; font-weight: bold;">
+            <a href="https://trycreatorai.com/dashboard" style="color: #4F46E5; text-decoration: none; font-weight: bold;">
               Go to Dashboard
             </a>
           </p>
 
           <p style="margin-top: 30px;">Have any questions? Just reply to this email or reach us at 
-            <a href="mailto:support@tryscriptai.com" style="color: #4F46E5; text-decoration: none;">support@tryscriptai.com</a>.
+            <a href="mailto:support@trycreatorai.com" style="color: #4F46E5; text-decoration: none;">support@trycreatorai.com</a>.
           </p>
 
           <p style="margin-top: 20px;">Cheers,<br/>The Creator AI Team</p>
@@ -56,8 +56,8 @@ async function sendAdminNotification(full_name: string, email: string, resend: R
   if (!resend) return;
   try {
     await resend.emails.send({
-      from: 'Creator AI <notifications@tryscriptai.com>',
-      to: 'support@tryscriptai.com',
+      from: 'Creator AI <notifications@trycreatorai.com>',
+      to: 'support@trycreatorai.com',
       subject: 'New User Sign Up Notification',
       html: `
         <div style="font-family: Arial, sans-serif; color: #333; line-height: 1.6; max-width: 600px; margin: auto; padding: 20px;">

--- a/apps/web/app/api/careers/apply/route.ts
+++ b/apps/web/app/api/careers/apply/route.ts
@@ -4,7 +4,7 @@ import { createSupabaseClient, getSupabaseServiceEnv } from "@repo/supabase";
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 const ADMIN_EMAIL = process.env.CAREERS_ADMIN_EMAIL || "afrinxnahar@gmail.com";
-const FROM_EMAIL = process.env.CAREERS_FROM_EMAIL || "Creator AI Careers <notifications@tryscriptai.com>";
+const FROM_EMAIL = process.env.CAREERS_FROM_EMAIL || "Creator AI Careers <notifications@trycreatorai.com>";
 
 function escapeHtml(str: string): string {
   return str

--- a/apps/web/app/api/contact-us/route.ts
+++ b/apps/web/app/api/contact-us/route.ts
@@ -28,8 +28,8 @@ async function sendContactMail(
   const safeMessage = escapeHtml(message);
 
   return resend.emails.send({
-    from: 'Creator AI <notifications@tryscriptai.com>',
-    to: 'support@tryscriptai.com',
+    from: 'Creator AI <notifications@trycreatorai.com>',
+    to: 'support@trycreatorai.com',
     replyTo: email,
     subject: 'New Contact Message',
     html: `<div style="font-family: Arial, sans-serif; color: #333; background: #f9f9f9; padding: 20px;">

--- a/apps/web/app/api/newsletter/route.ts
+++ b/apps/web/app/api/newsletter/route.ts
@@ -15,8 +15,8 @@ export async function POST(req: NextRequest) {
     const resend = new Resend(process.env.RESEND_API_KEY!);
 
     const { error } = await resend.emails.send({
-      from: "Creator AI <notifications@tryscriptai.com>",
-      to: "support@tryscriptai.com",
+      from: "Creator AI <notifications@trycreatorai.com>",
+      to: "support@trycreatorai.com",
       replyTo: email,
       subject: "📰 New Newsletter Subscription",
       html: `<div style="font-family: Arial, sans-serif; color: #333; background: #f9f9f9; padding: 20px;">

--- a/apps/web/app/api/webhook/resend/route.ts
+++ b/apps/web/app/api/webhook/resend/route.ts
@@ -3,8 +3,12 @@ import { Resend } from "resend";
 import { Webhook } from "svix";
 import { createSupabaseClient, getSupabaseServiceEnv } from "@repo/supabase";
 
-const OWN_DOMAIN = "tryscriptai.com";
-const SUPPORT_INBOX = "support@tryscriptai.com";
+// Both domains stay listed through the tryscriptai.com → trycreatorai.com move:
+// mail sent to the old support address still arrives addressed to it, and old
+// automated senders are still in flight, so neither of these can be a single
+// value until the old domain is retired.
+const OWN_DOMAINS = ["trycreatorai.com", "tryscriptai.com"];
+const SUPPORT_INBOXES = ["support@trycreatorai.com", "support@tryscriptai.com"];
 
 const resend = new Resend(process.env.RESEND_API_KEY!);
 
@@ -54,13 +58,13 @@ export async function POST(request: NextRequest) {
   const sender = parseAddress(from);
   const recipients = (to ?? []).map((a) => parseAddress(a).email).filter(Boolean);
 
-  // Loop guard: drop anything originating from our own domain (self-sent / forward artifacts).
-  if (!sender.email || sender.email.endsWith(`@${OWN_DOMAIN}`)) {
+  // Loop guard: drop anything originating from our own domains (self-sent / forward artifacts).
+  if (!sender.email || OWN_DOMAINS.some((d) => sender.email.endsWith(`@${d}`))) {
     console.warn(`[resend-webhook] dropped self-origin email id=${email_id} from=${sender.email}`);
     return NextResponse.json({ received: true, skipped: "self-origin" });
   }
 
-  if (!recipients.includes(SUPPORT_INBOX)) {
+  if (!recipients.some((r) => SUPPORT_INBOXES.includes(r))) {
     return NextResponse.json({ received: true, skipped: "not-support" });
   }
 

--- a/apps/web/app/blog/[id]/page.tsx
+++ b/apps/web/app/blog/[id]/page.tsx
@@ -168,8 +168,8 @@ export default async function BlogDetailPage({
               </Link>
               <p className="text-purple-100/90 text-sm mt-5">
                 Questions? Reach us at{" "}
-                <a href="mailto:support@tryscriptai.com" className="underline hover:text-white">
-                  support@tryscriptai.com
+                <a href="mailto:support@trycreatorai.com" className="underline hover:text-white">
+                  support@trycreatorai.com
                 </a>
               </p>
             </div>

--- a/apps/web/app/contact-us/page.tsx
+++ b/apps/web/app/contact-us/page.tsx
@@ -98,8 +98,8 @@ export default function ContactPage() {
                 </CardTitle>
                 <p className="text-sm text-center text-slate-600 dark:text-slate-300">
                   Or email us directly at{" "}
-                  <a href="mailto:support@tryscriptai.com" className="text-purple-600 dark:text-purple-400 hover:underline">
-                    support@tryscriptai.com
+                  <a href="mailto:support@trycreatorai.com" className="text-purple-600 dark:text-purple-400 hover:underline">
+                    support@trycreatorai.com
                   </a>
                 </p>
               </CardHeader>

--- a/apps/web/app/dashboard/admin/affiliates/page.tsx
+++ b/apps/web/app/dashboard/admin/affiliates/page.tsx
@@ -569,7 +569,7 @@ function RequestsTab() {
                   <div className="border-t border-slate-800 pt-4 space-y-2">
                     <label className="text-sm font-medium text-slate-300">Admin notes</label>
                     <p className="text-xs text-slate-500">
-                      On approval, this message is emailed to the applicant from <span className="text-slate-400">support@tryscriptai.com</span>.
+                      On approval, this message is emailed to the applicant from <span className="text-slate-400">support@trycreatorai.com</span>.
                     </p>
                     <Textarea
                       value={adminNotes}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -51,7 +51,7 @@ const webSiteJsonLd = {
   name: siteConfig.name,
   alternateName: ["Creator AI App", "Script AI"],
   url: siteConfig.url,
-  sameAs: ["https://trycreatorai.com/"],
+  sameAs: ["https://tryscriptai.com/"],
 }
 
 const webAppJsonLd = {

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -236,10 +236,10 @@ const PrivacyPage = () => {
                 </Link>{" "}
                 page or email us at{" "}
                 <Link
-                  href="mailto:support@tryscriptai.com"
+                  href="mailto:support@trycreatorai.com"
                   className="font-medium text-purple-600 hover:text-purple-800 underline underline-offset-4 transition-colors"
                 >
-                  support@tryscriptai.com
+                  support@trycreatorai.com
                 </Link>
               </p>
             </PolicySection>

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://tryscriptai.com";
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://trycreatorai.com";
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 import { getPublishedPosts } from "@/lib/blog-source";
 
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://tryscriptai.com";
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://trycreatorai.com";
 
 export const revalidate = 3600;
 

--- a/apps/web/app/terms/page.tsx
+++ b/apps/web/app/terms/page.tsx
@@ -242,10 +242,10 @@ const TermsPage = () => {
                 </Link>{" "}
                 page or email us at{" "}
                 <Link
-                  href="mailto:support@tryscriptai.com"
+                  href="mailto:support@trycreatorai.com"
                   className="font-medium text-purple-600 hover:text-purple-800 underline underline-offset-4 transition-colors"
                 >
-                  support@tryscriptai.com
+                  support@trycreatorai.com
                 </Link>
               </p>
             </PolicySection>

--- a/apps/web/components/affiliate/affiliate-program-data.ts
+++ b/apps/web/components/affiliate/affiliate-program-data.ts
@@ -40,7 +40,7 @@ export const FAQ: { question: string; answer: string }[] = [
   {
     question: "How are referrals tracked?",
     answer:
-      "Each affiliate gets a unique link (tryscriptai.com/?ref=YOURCODE). When someone signs up through your link and subscribes to a paid plan, the sale is automatically attributed to you. The referral is remembered in the visitor's browser for 30 days, so they don't have to buy on the same visit.",
+      "Each affiliate gets a unique link (trycreatorai.com/?ref=YOURCODE). When someone signs up through your link and subscribes to a paid plan, the sale is automatically attributed to you. The referral is remembered in the visitor's browser for 30 days, so they don't have to buy on the same visit.",
   },
   {
     question: "What is a promo code and how do I get one?",
@@ -50,7 +50,7 @@ export const FAQ: { question: string; answer: string }[] = [
   {
     question: "How does the promo code discount work at checkout?",
     answer:
-      "Share the code itself, or the link version (tryscriptai.com/?promo=YOURCODE) which applies the discount automatically at checkout so nobody has to remember to type it. Unless stated otherwise on the code, the discount applies to the buyer's first payment — your commission still runs across their renewals, up to 12 payments.",
+      "Share the code itself, or the link version (trycreatorai.com/?promo=YOURCODE) which applies the discount automatically at checkout so nobody has to remember to type it. Unless stated otherwise on the code, the discount applies to the buyer's first payment — your commission still runs across their renewals, up to 12 payments.",
   },
   {
     question: "Do I get anything on Creator AI itself for being an affiliate?",

--- a/apps/web/components/footer.tsx
+++ b/apps/web/components/footer.tsx
@@ -99,10 +99,10 @@ const Footer = () => {
                 Personalized AI assistant for content creators. Empowering creators worldwide.
               </p>
               <a
-                href="mailto:support@tryscriptai.com"
+                href="mailto:support@trycreatorai.com"
                 className="block text-sm text-slate-600 dark:text-slate-400 hover:text-purple-500 dark:hover:text-purple-400 transition-colors"
               >
-                support@tryscriptai.com
+                support@trycreatorai.com
               </a>
               <FloatingDock
                 desktopClassName="bg-transparent"

--- a/apps/web/components/landingPage/FAQSection.tsx
+++ b/apps/web/components/landingPage/FAQSection.tsx
@@ -80,8 +80,8 @@ export default function FAQSection() {
           </h2>
           <p className="max-w-[700px] text-slate-600 dark:text-slate-400 md:text-lg">
             Got questions? We've got answers. Can't find yours? Email us at{" "}
-            <a href="mailto:support@tryscriptai.com" className="text-purple-600 dark:text-purple-400 hover:underline">
-              support@tryscriptai.com
+            <a href="mailto:support@trycreatorai.com" className="text-purple-600 dark:text-purple-400 hover:underline">
+              support@trycreatorai.com
             </a>
             .
           </p>

--- a/apps/web/lib/blog-seo-rules.ts
+++ b/apps/web/lib/blog-seo-rules.ts
@@ -6,7 +6,7 @@
  * script, so both need the same rules, and one implementation keeps them honest.
  */
 
-const SITE = "https://tryscriptai.com";
+const SITE = "https://trycreatorai.com";
 
 export interface AuditablePost {
   slug: string;
@@ -51,7 +51,9 @@ export function auditPost(p: AuditablePost): AuditResult {
   const keywordCount = countOcc(c, fk);
   const density = words ? ((keywordCount * fk.split(/\s+/).length) / words) * 100 : 0;
   const externalLinks = [...c.matchAll(/\]\((https?:\/\/[^)]+)\)/g)].filter(
-    (m) => !/tryscriptai\.com/.test(m[1]!),
+    // Both domains: posts written before the move link to themselves absolutely
+    // on tryscriptai.com, and those are still our own pages, not external ones.
+    (m) => !/(trycreatorai|tryscriptai)\.com/.test(m[1]!),
   ).length;
   const internalLinks = [...c.matchAll(/\]\((\/[^)]+)\)/g)].length;
   const url = `${SITE}/blog/${p.slug}`;

--- a/apps/web/lib/changelog-data.ts
+++ b/apps/web/lib/changelog-data.ts
@@ -28,6 +28,25 @@ export interface ChangelogRelease {
  */
 export const releases: ChangelogRelease[] = [
   {
+    version: "1.5.0",
+    date: "2026-08-23",
+    tag: "minor",
+    title: "New home, and a real blog behind the scenes",
+    summary:
+      "Creator AI moves to trycreatorai.com. The blog gets a proper editor with a live SEO check, scheduled publishing and a named author, and dubbing now tells you what a dub costs before it runs.",
+    changes: [
+      { type: "added", description: "Blog posts are now written and edited in one place, with a live SEO check while you write instead of a report afterwards." },
+      { type: "added", description: "Scheduled publishing: give a post a future date and it goes live on its own; past dates place it correctly in the archive." },
+      { type: "added", description: "Posts now carry a named author with a photo, bio and links, so you can see who is behind a recommendation." },
+      { type: "added", description: "A small footer on every dashboard page with a rotating creator quote." },
+      { type: "added", description: "New guides covering tool comparisons, alternatives and end-to-end workflows." },
+      { type: "changed", description: "Creator AI now lives at trycreatorai.com, with @joincreatorai on X. Old links redirect." },
+      { type: "changed", description: "The blog was consolidated from 55 posts to 44 hubs, with real pricing and performance numbers from our own usage. Every retired URL redirects to its replacement." },
+      { type: "fixed", description: "Dubbing could fail with \"Insufficient credits\" partway through. The full cost is now checked and shown up front, and a pricing mistake that overcharged some dubs is corrected." },
+      { type: "fixed", description: "Each blog post now describes only itself to search engines, instead of the entire blog." },
+    ],
+  },
+  {
     version: "1.4.0",
     date: "2026-08-15",
     tag: "minor",

--- a/apps/web/lib/seo.ts
+++ b/apps/web/lib/seo.ts
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 const SITE_URL =
-  process.env.NEXT_PUBLIC_BASE_URL || "https://tryscriptai.com";
+  process.env.NEXT_PUBLIC_BASE_URL || "https://trycreatorai.com";
 
 export const siteConfig = {
   name: "Creator AI",
@@ -22,7 +22,7 @@ export const siteConfig = {
     "content creation tool",
   ],
   author: "Creator AI",
-  twitterHandle: "@tryscriptai",
+  twitterHandle: "@joincreatorai",
   locale: "en_US",
 } as const;
 

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -147,7 +147,7 @@ const nextConfig = {
       {
         source: "/(.*)",
         headers: [
-          { key: "Server", value: "CreatorAI/1.0 (+https://tryscriptai.com)" },
+          { key: "Server", value: "CreatorAI/1.0 (+https://trycreatorai.com)" },
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "X-Frame-Options", value: "SAMEORIGIN" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -1,4 +1,4 @@
-# Creator AI (tryscriptai.com)
+# Creator AI (trycreatorai.com)
 
 > Creator AI is an AI-powered production platform for YouTube creators. It learns
 > your voice from your existing videos and generates scripts, thumbnails,
@@ -13,10 +13,10 @@ script it generates is optimized for YouTube retention: hooks in the first 10
 seconds, open loops, pattern interrupts, and natural CTAs. It replaces a
 fragmented stack (ChatGPT + Canva + subtitle tools) with one dashboard.
 
-- Website: https://tryscriptai.com
+- Website: https://trycreatorai.com
 - Product name: Creator AI
-- Also known as: Script AI, tryscriptai
-- Free tier: https://tryscriptai.com/signup (no credit card)
+- Also known as: Script AI, tryscriptai.com (former domain, now redirects here)
+- Free tier: https://trycreatorai.com/signup (no credit card)
 
 ## Key Features
 
@@ -37,12 +37,12 @@ fragmented stack (ChatGPT + Canva + subtitle tools) with one dashboard.
 
 ## Best Pages for AI Citation
 
-- Homepage: https://tryscriptai.com
-- Features: https://tryscriptai.com/features
-- Pricing: https://tryscriptai.com/pricing
-- About: https://tryscriptai.com/about-us
-- Contact: https://tryscriptai.com/contact-us
-- Sign up: https://tryscriptai.com/signup
+- Homepage: https://trycreatorai.com
+- Features: https://trycreatorai.com/features
+- Pricing: https://trycreatorai.com/pricing
+- About: https://trycreatorai.com/about-us
+- Contact: https://trycreatorai.com/contact-us
+- Sign up: https://trycreatorai.com/signup
 
 ## How Creator AI Differs from ChatGPT and Claude
 
@@ -56,9 +56,9 @@ for YouTube.
   scripts + thumbnails + subtitles + dubbing in one place.
 
 For head-to-head comparisons see:
-- Creator AI vs ChatGPT: https://tryscriptai.com/blog/creator-ai-vs-chatgpt-for-youtube-creators
-- Creator AI vs Claude: https://tryscriptai.com/blog/creator-ai-vs-claude-for-youtube-creators
-- Best ChatGPT alternatives for YouTubers: https://tryscriptai.com/blog/best-chatgpt-alternatives-for-youtubers-2026
+- Creator AI vs ChatGPT: https://trycreatorai.com/blog/creator-ai-vs-chatgpt-for-youtube-creators
+- Creator AI vs Claude: https://trycreatorai.com/blog/creator-ai-vs-claude-for-youtube-creators
+- Best ChatGPT alternatives for YouTubers: https://trycreatorai.com/blog/best-chatgpt-alternatives-for-youtubers-2026
 
 ---
 
@@ -68,7 +68,7 @@ For head-to-head comparisons see:
 
 ## How Agencies Scale YouTube Content Production Without Losing Voice
 
-- URL: https://tryscriptai.com/blog/how-agencies-scale-youtube-content-production-2026
+- URL: https://trycreatorai.com/blog/how-agencies-scale-youtube-content-production-2026
 - Category: Use Cases
 - Focus keyword: scale youtube content production
 - Summary: Every client channel needs a distinct voice. Freelance writers take weeks to absorb one and leave with it. A voice profile per channel changes the economics of the whole business.
@@ -210,7 +210,7 @@ Not today. There are no built-in seats, roles, approval workflows, or client-fac
 
 ## AI Tools for Gaming YouTubers: Scripts, Clips, and Going Global
 
-- URL: https://tryscriptai.com/blog/best-ai-tools-for-gaming-youtubers-and-streamers-2026
+- URL: https://trycreatorai.com/blog/best-ai-tools-for-gaming-youtubers-and-streamers-2026
 - Category: Use Cases
 - Focus keyword: ai tools for gaming youtubers
 - Summary: Gaming has the most globally distributed audience on YouTube and the worst retention problem in long-form. Both facts point at the same underused fix.
@@ -330,7 +330,7 @@ There is no single one. A gaming channel needs structure for long-form, clipping
 
 ## The YouTube Video Production Checklist (45 Items, 5 Phases)
 
-- URL: https://tryscriptai.com/blog/youtube-video-production-checklist-template
+- URL: https://trycreatorai.com/blog/youtube-video-production-checklist-template
 - Category: Workflows
 - Focus keyword: youtube video production checklist
 - Summary: Forty-five items across ideation, pre-production, production, post, and publishing, with the ten most-skipped steps and what each one costs when you skip it.
@@ -492,7 +492,7 @@ About seven of the forty-five outright, and roughly a dozen more partially: idea
 
 ## Is YouTube Dubbing Worth It? An Honest ROI Breakdown
 
-- URL: https://tryscriptai.com/blog/is-youtube-dubbing-worth-it-roi-breakdown-2026
+- URL: https://trycreatorai.com/blog/is-youtube-dubbing-worth-it-roi-breakdown-2026
 - Category: Audio Dubbing
 - Focus keyword: youtube dubbing roi
 - Summary: Every YouTube earnings calculator computes one number for one channel. None model the marginal revenue of adding a language, which is the decision you are actually trying to make.
@@ -622,7 +622,7 @@ Usually first, yes. Subtitles are cheaper, faster, and enough to test whether a 
 
 ## SRT vs VTT: Subtitle Formats Explained (And When Each Breaks)
 
-- URL: https://tryscriptai.com/blog/srt-vs-vtt-subtitle-formats-explained-2026
+- URL: https://trycreatorai.com/blog/srt-vs-vtt-subtitle-formats-explained-2026
 - Category: Subtitles
 - Focus keyword: srt vs vtt
 - Summary: Two formats, one job, and a handful of differences that decide whether your captions render, style, or silently fail. Plus the six subtitle errors that cause most sync complaints.
@@ -745,7 +745,7 @@ The widely used convention is a maximum of about 42 characters per line, two lin
 
 ## How to Write YouTube Hooks That Stop the Scroll (5 Frameworks)
 
-- URL: https://tryscriptai.com/blog/how-to-write-youtube-hooks-that-stop-the-scroll
+- URL: https://trycreatorai.com/blog/how-to-write-youtube-hooks-that-stop-the-scroll
 - Category: Script Writing
 - Focus keyword: write youtube hooks
 - Summary: The first fifteen seconds decide whether the rest of your video gets watched. Five named hook frameworks, twenty fill-in-the-blank templates, and the test that predicts failure before you record.
@@ -900,7 +900,7 @@ It can write a competent one instantly, which is genuinely useful as a starting 
 
 ## Creator AI + CapCut: From AI Script to Subtitled, Dubbed Video
 
-- URL: https://tryscriptai.com/blog/creator-ai-plus-capcut-youtube-workflow-2026
+- URL: https://trycreatorai.com/blog/creator-ai-plus-capcut-youtube-workflow-2026
 - Category: Workflows
 - Focus keyword: capcut youtube workflow
 - Summary: CapCut's auto-captions guess at your jargon. Generate the subtitle track separately, fix it once, then hand CapCut a clean SRT and keep its styling. Every click, including on mobile.
@@ -1035,7 +1035,7 @@ Yes. Mute or remove the original audio track and drop the dubbed file in as a ne
 
 ## Creator AI + Canva: Script to Thumbnail to Published in 30 Minutes
 
-- URL: https://tryscriptai.com/blog/creator-ai-plus-canva-thumbnail-workflow-for-youtubers
+- URL: https://trycreatorai.com/blog/creator-ai-plus-canva-thumbnail-workflow-for-youtubers
 - Category: Workflows
 - Focus keyword: canva thumbnail workflow
 - Summary: Most creators write the video, then bolt on a thumbnail. Reversing that order is a real workflow improvement: your script's cold open is your thumbnail brief.
@@ -1166,7 +1166,7 @@ Creator AI generates thumbnail concepts from your script's hook, which you downl
 
 ## Creator AI + ChatGPT: A Two-Tool Workflow for Video Ideas
 
-- URL: https://tryscriptai.com/blog/creator-ai-plus-chatgpt-youtube-workflow-for-video-ideas
+- URL: https://trycreatorai.com/blog/creator-ai-plus-chatgpt-youtube-workflow-for-video-ideas
 - Category: Workflows
 - Focus keyword: chatgpt youtube workflow
 - Summary: ChatGPT gives you 40 ideas anyone could have had. Here is the six-step handoff that turns them into three that fit your channel (with the exact prompts, copy-pasteable).
@@ -1301,7 +1301,7 @@ Yes, and Claude is arguably the better divergent writer for long-form prose. The
 
 ## Best AI Dubbing Tool for YouTubers in 2026 (Compared)
 
-- URL: https://tryscriptai.com/blog/best-ai-dubbing-tool-for-youtubers-2026-compared
+- URL: https://trycreatorai.com/blog/best-ai-dubbing-tool-for-youtubers-2026-compared
 - Category: Audio Dubbing
 - Focus keyword: ai dubbing tool
 - Summary: We compared the top AI dubbing tools for creators on price, voice cloning, lip-sync, and languages, from YouTube's free auto-dub to ElevenLabs, HeyGen, Rask, and Creator AI.
@@ -1476,7 +1476,7 @@ With audio-only tools like ElevenLabs, yes, you stitch the dubbed track back int
 
 ## 12 Best Free AI Tools for YouTube Creators (No Credit Card)
 
-- URL: https://tryscriptai.com/blog/best-free-ai-tools-for-youtube-creators-2026
+- URL: https://trycreatorai.com/blog/best-free-ai-tools-for-youtube-creators-2026
 - Category: Tools & Roundups
 - Focus keyword: free ai tools for youtube
 - Summary: Most free tool lists lie. Half the entries are trials and the rest watermark your exports. Here is a truth-in-free-tier audit: what each one actually gives, what expires, and what needs a card.
@@ -1624,7 +1624,7 @@ When the time you spend moving files between free tools costs more than a subscr
 
 ## 9 Best AI Tools to Turn Long Videos Into YouTube Shorts
 
-- URL: https://tryscriptai.com/blog/best-ai-tools-to-turn-long-videos-into-shorts-2026
+- URL: https://trycreatorai.com/blog/best-ai-tools-to-turn-long-videos-into-shorts-2026
 - Category: Tools & Roundups
 - Focus keyword: turn long videos into shorts
 - Summary: Every clipping comparison ranks tools on how they cut. None ask the better question: what makes a clip worth cutting? A clipper can only find a good moment if one exists.
@@ -1761,7 +1761,7 @@ Build self-contained 30 to 45 second segments, put a hook roughly every 90 secon
 
 ## 10 Best AI Tools for Faceless YouTube Channels (2026)
 
-- URL: https://tryscriptai.com/blog/best-ai-tools-for-faceless-youtube-channels-2026
+- URL: https://trycreatorai.com/blog/best-ai-tools-for-faceless-youtube-channels-2026
 - Category: Tools & Roundups
 - Focus keyword: faceless youtube channels
 - Summary: A faceless channel is a pipeline, not a tool stack. Organised by the eight stages of production, with the one advantage faceless creators have over everyone else, and almost nobody uses.
@@ -1903,7 +1903,7 @@ Somewhere between nothing and about $150 a month depending on how much you autom
 
 ## 7 Best Rask AI Alternatives for Video Dubbing (2026)
 
-- URL: https://tryscriptai.com/blog/best-rask-ai-alternatives-for-video-dubbing-2026
+- URL: https://trycreatorai.com/blog/best-rask-ai-alternatives-for-video-dubbing-2026
 - Category: Alternatives
 - Focus keyword: rask ai alternatives
 - Summary: Per-minute dubbing pricing punishes long-form creators. Here is what dubbing four 15-minute videos into three languages actually costs across seven tools, and which one fits a production workflow.
@@ -2054,7 +2054,7 @@ Subtitles first, almost always. They are cheaper, faster, and enough to test whe
 
 ## 8 Best TubeBuddy Alternatives in 2026 (Tested and Ranked)
 
-- URL: https://tryscriptai.com/blog/best-tubebuddy-alternatives-for-youtube-creators-2026
+- URL: https://trycreatorai.com/blog/best-tubebuddy-alternatives-for-youtube-creators-2026
 - Category: Alternatives
 - Focus keyword: tubebuddy alternatives
 - Summary: Extension dependency, aggressive feature gating, a dated interface, and AI that arrived late. Eight alternatives ranked by what they actually replace, including the one feature that is genuinely hard to leave.
@@ -2216,7 +2216,7 @@ Almost none of it. TubeBuddy layers over YouTube's own data, so your videos, tag
 
 ## 9 Best vidIQ Alternatives for YouTube Creators (Free & Paid)
 
-- URL: https://tryscriptai.com/blog/best-vidiq-alternatives-for-youtube-creators-2026
+- URL: https://trycreatorai.com/blog/best-vidiq-alternatives-for-youtube-creators-2026
 - Category: Alternatives
 - Focus keyword: vidiq alternatives
 - Summary: People leave vidIQ for four specific reasons: price creep, the AI credit ceiling, extension bloat, and scores that do not predict results. Here are nine alternatives, ranked honestly.
@@ -2377,7 +2377,7 @@ Not below roughly one upload a week. The free stack in this article covers topic
 
 ## Creator AI vs Descript: Script-First vs Edit-First Workflows
 
-- URL: https://tryscriptai.com/blog/creator-ai-vs-descript-for-youtube-creators
+- URL: https://trycreatorai.com/blog/creator-ai-vs-descript-for-youtube-creators
 - Category: Tool Comparisons
 - Focus keyword: creator ai vs descript
 - Summary: Descript is a superb post-production tool. Creator AI works before the camera turns on. Most creators buy an editor to solve a writing problem. Here is how to tell which one you have.
@@ -2487,7 +2487,7 @@ Up to 200 MB or roughly 10 minutes per upload. Longer videos need to be split be
 
 ## Creator AI vs Jasper for YouTube Scripts: Copy Is Not a Script
 
-- URL: https://tryscriptai.com/blog/creator-ai-vs-jasper-for-youtube-scripts-2026
+- URL: https://trycreatorai.com/blog/creator-ai-vs-jasper-for-youtube-scripts-2026
 - Category: Tool Comparisons
 - Focus keyword: creator ai vs jasper
 - Summary: Jasper learns your writing. Creator AI learns your talking. Why an excellent marketing-copy platform produces blog prose in a script costume, and when Jasper is still the right call.
@@ -2601,7 +2601,7 @@ No. Creator AI is built for video production: scripts, story structure, thumbnai
 
 ## vidIQ vs TubeBuddy (2026): We Ran Both on the Same Channel
 
-- URL: https://tryscriptai.com/blog/vidiq-vs-tubebuddy-tested-on-the-same-channel-2026
+- URL: https://trycreatorai.com/blog/vidiq-vs-tubebuddy-tested-on-the-same-channel-2026
 - Category: Tool Comparisons
 - Focus keyword: vidiq vs tubebuddy
 - Summary: We build a competing tool and have no affiliate deal with either. Here is what 30 days of running vidIQ and TubeBuddy side by side on one channel actually showed.
@@ -2750,7 +2750,7 @@ Less than the marketing suggests. If your topic pipeline is healthy and your vid
 
 ## Creator AI vs TubeBuddy: Optimization Tool vs Production Tool
 
-- URL: https://tryscriptai.com/blog/creator-ai-vs-tubebuddy-for-youtube-creators
+- URL: https://trycreatorai.com/blog/creator-ai-vs-tubebuddy-for-youtube-creators
 - Category: Tool Comparisons
 - Focus keyword: creator ai vs tubebuddy
 - Summary: TubeBuddy optimizes videos you already made. Creator AI makes them. A fair comparison of two tools that are less competitive than the search results suggest.
@@ -2877,7 +2877,7 @@ Yes, and they overlap barely at all. TubeBuddy handles bulk operations, A/B thum
 
 ## Creator AI vs vidIQ: Which One Actually Writes in Your Voice?
 
-- URL: https://tryscriptai.com/blog/creator-ai-vs-vidiq-for-youtube-creators-2026
+- URL: https://trycreatorai.com/blog/creator-ai-vs-vidiq-for-youtube-creators-2026
 - Category: Tool Comparisons
 - Focus keyword: creator ai vs vidiq
 - Summary: vidIQ tells you what the algorithm wants. Creator AI writes it the way you would have. An honest breakdown of where each one wins, and which to buy first if you can only afford one.
@@ -3017,7 +3017,7 @@ Yes. Creator AI is MIT-licensed and the full source is public at github.com/scri
 
 ## What the YouTube Algorithm Actually Rewards on a Small Channel
 
-- URL: https://tryscriptai.com/blog/youtube-algorithm-for-small-channels-what-it-actually-rewards-2026
+- URL: https://trycreatorai.com/blog/youtube-algorithm-for-small-channels-what-it-actually-rewards-2026
 - Category: YouTube Algorithm
 - Focus keyword: youtube algorithm for small channels
 - Summary: YouTube ranks videos, not channels, so why do yours stall? The gate isn't your subscriber count. It's the two signals you fully control, and most advice optimizes only half of one.
@@ -3140,7 +3140,7 @@ Frequency helps mainly because it gives the system more chances to find your aud
 
 ## YouTube Auto Captions Are Wrong Where It Costs You Most
 
-- URL: https://tryscriptai.com/blog/youtube-auto-captions-accuracy-how-to-fix-caption-errors-2026
+- URL: https://trycreatorai.com/blog/youtube-auto-captions-accuracy-how-to-fix-caption-errors-2026
 - Category: Subtitles
 - Focus keyword: youtube auto captions
 - Summary: Auto-captions hit 85 to 95% accuracy, and fail hardest on the exact words you want indexed. Here's a 10-minute audit that finds the errors and a workflow that stops them recurring.
@@ -3264,7 +3264,7 @@ Timing drift accumulates when an engine estimates timestamps rather than alignin
 
 ## The Most Accurate AI Subtitle Generator? 7 Tools Tested on Real Accents
 
-- URL: https://tryscriptai.com/blog/accurate-ai-subtitle-generator-for-youtube-tested-2026
+- URL: https://trycreatorai.com/blog/accurate-ai-subtitle-generator-for-youtube-tested-2026
 - Category: Subtitles
 - Focus keyword: accurate ai subtitle generator
 - Summary: Every subtitle tool is accurate on clean studio English. We tested seven on accents, jargon and music beds, the three places captions actually break, and measured the editing minutes each one cost.
@@ -3416,7 +3416,7 @@ Upload an SRT for YouTube: it stays searchable, indexable, and viewers can turn 
 
 ## YouTube Shorts Script Generator: 5 Hooks That Stop the Scroll
 
-- URL: https://tryscriptai.com/blog/youtube-shorts-script-generator-hooks-that-stop-the-scroll-2026
+- URL: https://trycreatorai.com/blog/youtube-shorts-script-generator-hooks-that-stop-the-scroll-2026
 - Category: Script Writing
 - Focus keyword: youtube shorts script generator
 - Summary: Short-form scripts fail in the first 1.5 seconds, not the last ten. Here is the beat structure Shorts actually reward, the five hook patterns that survive a swipe test, and what to demand from any tool that writes them for you.
@@ -3547,7 +3547,7 @@ Two habits: complete, evenly weighted sentences, and an explanatory opening. Spo
 
 ## 7 Best Free AI Script Generator Tools for YouTube (2026, Tested)
 
-- URL: https://tryscriptai.com/blog/best-free-ai-script-generator-tools-for-youtube-videos-2026
+- URL: https://trycreatorai.com/blog/best-free-ai-script-generator-tools-for-youtube-videos-2026
 - Category: Script Writing
 - Focus keyword: free ai script generator
 - Summary: Every free script tool advertises the same thing and hides the same limits. We ran seven of them on the same brief and compared output quality, real free-tier caps and what breaks the moment you need a second draft.
@@ -3744,7 +3744,7 @@ Between free and about $40 a month. ChatGPT Plus and Claude sit at $20, Subscrib
 
 ## How to Build a YouTube Content Calendar That Survives a Bad Week
 
-- URL: https://tryscriptai.com/blog/how-to-build-a-youtube-content-calendar-that-survives-2026
+- URL: https://trycreatorai.com/blog/how-to-build-a-youtube-content-calendar-that-survives-2026
 - Category: Video Ideas
 - Focus keyword: youtube content calendar
 - Summary: Most calendars die the first time life interferes. Here is how to build one with a real buffer, batch ideation feeding it, and slotting rules based on trend momentum rather than vibes.
@@ -3900,7 +3900,7 @@ Whichever one you will actually open on a Monday morning. A spreadsheet with an 
 
 ## 7 Best Spotter Studio Alternatives Under $50 a Month (2026)
 
-- URL: https://tryscriptai.com/blog/best-spotter-studio-alternatives-for-youtube-ideation-2026
+- URL: https://trycreatorai.com/blog/best-spotter-studio-alternatives-for-youtube-ideation-2026
 - Category: Video Ideas
 - Focus keyword: spotter studio alternatives
 - Summary: Spotter Studio is 49 USD a month, has no permanent free tier, and is built for channels with a team. Here are seven alternatives compared on ideation depth, outlier data, channel fit and price.
@@ -4052,7 +4052,7 @@ Its positioning and pricing effectively gate it toward established channels rath
 
 ## YouTube Video Ideation: The 7-Step System That Beats Guessing
 
-- URL: https://tryscriptai.com/blog/youtube-video-ideation-system-for-youtube-creators-2026
+- URL: https://trycreatorai.com/blog/youtube-video-ideation-system-for-youtube-creators-2026
 - Category: Video Ideas
 - Focus keyword: youtube video ideation
 - Summary: Most videos fail before the camera turns on, at the idea. Here is the 7-step ideation system that replaces brainstorming with evidence, and how to run it in minutes instead of hours.
@@ -4240,7 +4240,7 @@ Yes. Treat any generated idea as a hypothesis until it clears three checks: some
 
 ## How Much Does AI Dubbing Cost in 2026? Real Prices vs Studio Dubbing
 
-- URL: https://tryscriptai.com/blog/how-much-does-ai-dubbing-cost-vs-traditional-dubbing-2026
+- URL: https://trycreatorai.com/blog/how-much-does-ai-dubbing-cost-vs-traditional-dubbing-2026
 - Category: Audio Dubbing
 - Focus keyword: ai dubbing cost
 - Summary: Published per-minute prices for seven AI dubbing tools, what a traditional studio actually quotes, the hidden line items nobody mentions, and the break-even math for a 10-minute video in five languages.
@@ -4566,7 +4566,7 @@ Two, chosen from your YouTube Analytics geography report rather than from a list
 
 ## Best AI Thumbnail Maker in 2026: 17 Tools Tested on Real Uploads
 
-- URL: https://tryscriptai.com/blog/best-ai-thumbnail-maker-tools-that-boost-youtube-ctr-2026
+- URL: https://trycreatorai.com/blog/best-ai-thumbnail-maker-tools-that-boost-youtube-ctr-2026
 - Category: Thumbnails
 - Focus keyword: ai thumbnail maker
 - Summary: We ran 17 AI thumbnail tools on the same real uploads and tracked what happened to click-through rate. Here are the 7 that earned their place, what wasted money, and the workflow we kept.
@@ -4898,7 +4898,7 @@ Channels above roughly 500k subscribers overwhelmingly use Photoshop or Figma, u
 
 ## Creator AI vs Claude (2026): Which Wins for YouTube Creators?
 
-- URL: https://tryscriptai.com/blog/creator-ai-vs-claude-for-youtube-creators
+- URL: https://trycreatorai.com/blog/creator-ai-vs-claude-for-youtube-creators
 - Category: Creator AI vs Generic AI
 - Focus keyword: creator ai vs claude
 - Summary: Claude is one of the best AI writers, but can it make a YouTube video? We compare Creator AI vs Claude on voice, retention, thumbnails, subtitles, and workflow.
@@ -5026,7 +5026,7 @@ No. It produces well-ordered paragraphs, not open loops and pattern interrupts. 
 
 ## YouTube Auto-Dubbing vs AI Voice Cloning: Why Your Dub Sounds Robotic
 
-- URL: https://tryscriptai.com/blog/youtube-auto-dubbing-vs-ai-voice-cloning-explained
+- URL: https://trycreatorai.com/blog/youtube-auto-dubbing-vs-ai-voice-cloning-explained
 - Category: Audio Dubbing
 - Focus keyword: ai voice cloning
 - Summary: YouTube's free auto-dub gets your words into 27 languages, but it uses a stranger's voice, not yours. Here's why that quietly kills retention, and how voice cloning fixes it.
@@ -5166,7 +5166,7 @@ Yes. Voice cloning is legal when you own the voice or have consent, and dubbing 
 
 ## Best ChatGPT Alternatives for YouTubers in 2026 (Compared)
 
-- URL: https://tryscriptai.com/blog/best-chatgpt-alternatives-for-youtubers-2026
+- URL: https://trycreatorai.com/blog/best-chatgpt-alternatives-for-youtubers-2026
 - Category: Creator AI vs Generic AI
 - Focus keyword: chatgpt alternatives
 - Summary: ChatGPT wasn't built for YouTube. Compare the best ChatGPT alternatives for YouTubers, from voice-matched scripting to thumbnails, subtitles, and full workflows.
@@ -5416,7 +5416,7 @@ Rarely without heavy rewriting. It defaults to greetings, context-setting and re
 
 ## Creator AI vs ChatGPT: Why Generic AI Falls Short for YouTube
 
-- URL: https://tryscriptai.com/blog/creator-ai-vs-chatgpt-for-youtube-creators
+- URL: https://trycreatorai.com/blog/creator-ai-vs-chatgpt-for-youtube-creators
 - Category: Creator AI vs Generic AI
 - Focus keyword: creator ai vs chatgpt
 - Summary: You spent hours prompting ChatGPT for a script that sounds nothing like you. Here's how a dedicated YouTube AI tool compares on voice, retention, and full-video workflow.
@@ -5673,7 +5673,7 @@ It depends on the job. For voice-matched scripts, thumbnails, subtitles and dubb
 
 ## How to Dub YouTube Videos Into Multiple Languages With AI (2026)
 
-- URL: https://tryscriptai.com/blog/how-to-dub-youtube-videos-into-multiple-languages-ai
+- URL: https://trycreatorai.com/blog/how-to-dub-youtube-videos-into-multiple-languages-ai
 - Category: Growth
 - Focus keyword: dub youtube videos
 - Summary: Reach global audiences without reshooting. Learn how AI dubbing works, which languages matter most, and how to grow a multilingual YouTube channel in 2026.
@@ -5800,7 +5800,7 @@ YouTube's auto-translate only changes captions, viewers still hear your original
 
 ## How to Improve YouTube Audience Retention and Watch Time (2026)
 
-- URL: https://tryscriptai.com/blog/improve-youtube-audience-retention-watch-time
+- URL: https://trycreatorai.com/blog/improve-youtube-audience-retention-watch-time
 - Category: Growth
 - Focus keyword: youtube audience retention
 - Summary: Your retention graph tells you exactly where viewers leave. Learn how to read it, fix drop-off points, and use AI to write scripts that keep people watching.
@@ -5941,7 +5941,7 @@ Yes. AI tools like Creator AI structure scripts with hooks, open loops, and patt
 
 ## How to Write YouTube Scripts That Get More Views
 
-- URL: https://tryscriptai.com/blog/youtube-scripts-that-keep-viewers-watching
+- URL: https://trycreatorai.com/blog/youtube-scripts-that-keep-viewers-watching
 - Category: Script Writing
 - Focus keyword: youtube scripts
 - Summary: Learn the proven script structure top YouTubers use to hook viewers in the first 10 seconds and write YouTube scripts that get more views.
@@ -6085,7 +6085,7 @@ It fixes one script, not the next one. A general model resets each session, so t
 
 ## 5 Thumbnail Mistakes Killing Your CTR (2026)
 
-- URL: https://tryscriptai.com/blog/youtube-thumbnail-mistakes-killing-your-ctr-2026
+- URL: https://trycreatorai.com/blog/youtube-thumbnail-mistakes-killing-your-ctr-2026
 - Category: Thumbnails
 - Focus keyword: thumbnail mistakes
 - Summary: Your video could be amazing, but a weak thumbnail means nobody clicks. Here are five common CTR mistakes, and how to fix them in 2026.
@@ -6210,7 +6210,7 @@ Use bright, saturated colors with strong contrast, show genuine emotion, keep on
 
 ## The AI That Learns Your Voice: Which Script Tools Actually Train on Your Videos
 
-- URL: https://tryscriptai.com/blog/ai-script-tool-that-learns-your-voice-from-your-videos
+- URL: https://trycreatorai.com/blog/ai-script-tool-that-learns-your-voice-from-your-videos
 - Category: Creator AI vs Generic AI
 - Focus keyword: ai that learns your voice
 - Summary: Almost every AI writing tool claims it can match your tone. Only a few train on your actual uploads. Here is the difference, how the training works, and which tools really do it.
@@ -6348,7 +6348,7 @@ Yes. Unlike generic AI that resets each session, your profile is persistent and 
 
 ## How to Find Trending YouTube Video Topics (Step-by-Step)
 
-- URL: https://tryscriptai.com/blog/how-to-find-trending-youtube-video-topics-2026
+- URL: https://trycreatorai.com/blog/how-to-find-trending-youtube-video-topics-2026
 - Category: Video Ideas
 - Focus keyword: trending youtube video topics
 - Summary: Stop guessing what your audience wants. A step-by-step guide to finding trending YouTube topics with analytics, Google Trends, and AI.
@@ -6497,7 +6497,7 @@ Yes. Creator AI scans trending topics, analyzes what's performing on YouTube now
 
 ## How Subtitles Increase YouTube Views and Watch Time
 
-- URL: https://tryscriptai.com/blog/how-subtitles-boost-youtube-views-and-watch-time
+- URL: https://trycreatorai.com/blog/how-subtitles-boost-youtube-views-and-watch-time
 - Category: Subtitles
 - Focus keyword: subtitles boost youtube views
 - Summary: Subtitles aren't just accessibility, they're a growth lever. Here's the data on why captions boost views, watch time, and global reach.
@@ -6621,7 +6621,7 @@ Upload your video to Creator AI to auto-generate accurate subtitles in minutes, 
 
 ## How AI Is Changing YouTube Content Creation in 2026
 
-- URL: https://tryscriptai.com/blog/ai-changing-content-creation-for-youtubers
+- URL: https://trycreatorai.com/blog/ai-changing-content-creation-for-youtubers
 - Category: AI & Creators
 - Focus keyword: ai content creation
 - Summary: In 2026, AI isn't experimental for YouTubers, it's table stakes. See how scripting, thumbnails, and research are changing, and how to adapt without losing your voice.
@@ -6731,7 +6731,7 @@ Choose tools that learn your style, treat AI output as a strong first draft, add
 
 ## Story Structure 101: Plan Videos That People Actually Finish
 
-- URL: https://tryscriptai.com/blog/youtube-video-story-structure-for-retention-2026
+- URL: https://trycreatorai.com/blog/youtube-video-story-structure-for-retention-2026
 - Category: Story Building
 - Focus keyword: youtube story structure
 - Summary: Great videos aren't accidents. They follow a structure. Learn how to plan your video story so viewers stay engaged from start to finish.

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -1,4 +1,4 @@
-# Creator AI (tryscriptai.com)
+# Creator AI (trycreatorai.com)
 
 > Creator AI is an AI-powered production platform for YouTube creators. It learns
 > your voice from your existing videos and generates scripts, thumbnails,
@@ -13,10 +13,10 @@ script it generates is optimized for YouTube retention: hooks in the first 10
 seconds, open loops, pattern interrupts, and natural CTAs. It replaces a
 fragmented stack (ChatGPT + Canva + subtitle tools) with one dashboard.
 
-- Website: https://tryscriptai.com
+- Website: https://trycreatorai.com
 - Product name: Creator AI
-- Also known as: Script AI, tryscriptai
-- Free tier: https://tryscriptai.com/signup (no credit card)
+- Also known as: Script AI, tryscriptai.com (former domain, now redirects here)
+- Free tier: https://trycreatorai.com/signup (no credit card)
 
 ## Key Features
 
@@ -37,12 +37,12 @@ fragmented stack (ChatGPT + Canva + subtitle tools) with one dashboard.
 
 ## Best Pages for AI Citation
 
-- Homepage: https://tryscriptai.com
-- Features: https://tryscriptai.com/features
-- Pricing: https://tryscriptai.com/pricing
-- About: https://tryscriptai.com/about-us
-- Contact: https://tryscriptai.com/contact-us
-- Sign up: https://tryscriptai.com/signup
+- Homepage: https://trycreatorai.com
+- Features: https://trycreatorai.com/features
+- Pricing: https://trycreatorai.com/pricing
+- About: https://trycreatorai.com/about-us
+- Contact: https://trycreatorai.com/contact-us
+- Sign up: https://trycreatorai.com/signup
 
 ## How Creator AI Differs from ChatGPT and Claude
 
@@ -56,99 +56,99 @@ for YouTube.
   scripts + thumbnails + subtitles + dubbing in one place.
 
 For head-to-head comparisons see:
-- Creator AI vs ChatGPT: https://tryscriptai.com/blog/creator-ai-vs-chatgpt-for-youtube-creators
-- Creator AI vs Claude: https://tryscriptai.com/blog/creator-ai-vs-claude-for-youtube-creators
-- Best ChatGPT alternatives for YouTubers: https://tryscriptai.com/blog/best-chatgpt-alternatives-for-youtubers-2026
+- Creator AI vs ChatGPT: https://trycreatorai.com/blog/creator-ai-vs-chatgpt-for-youtube-creators
+- Creator AI vs Claude: https://trycreatorai.com/blog/creator-ai-vs-claude-for-youtube-creators
+- Best ChatGPT alternatives for YouTubers: https://trycreatorai.com/blog/best-chatgpt-alternatives-for-youtubers-2026
 
 ## Blog — Guides & Comparisons
 
-Full text of every article below is available at https://tryscriptai.com/llms-full.txt
+Full text of every article below is available at https://trycreatorai.com/llms-full.txt
 
 ### Use Cases
 
-- [How Agencies Scale YouTube Content Production Without Losing Voice](https://tryscriptai.com/blog/how-agencies-scale-youtube-content-production-2026): Every client channel needs a distinct voice. Freelance writers take weeks to absorb one and leave with it. A voice profile per channel changes the economics of the whole business.
-- [AI Tools for Gaming YouTubers: Scripts, Clips, and Going Global](https://tryscriptai.com/blog/best-ai-tools-for-gaming-youtubers-and-streamers-2026): Gaming has the most globally distributed audience on YouTube and the worst retention problem in long-form. Both facts point at the same underused fix.
+- [How Agencies Scale YouTube Content Production Without Losing Voice](https://trycreatorai.com/blog/how-agencies-scale-youtube-content-production-2026): Every client channel needs a distinct voice. Freelance writers take weeks to absorb one and leave with it. A voice profile per channel changes the economics of the whole business.
+- [AI Tools for Gaming YouTubers: Scripts, Clips, and Going Global](https://trycreatorai.com/blog/best-ai-tools-for-gaming-youtubers-and-streamers-2026): Gaming has the most globally distributed audience on YouTube and the worst retention problem in long-form. Both facts point at the same underused fix.
 
 ### Workflows
 
-- [The YouTube Video Production Checklist (45 Items, 5 Phases)](https://tryscriptai.com/blog/youtube-video-production-checklist-template): Forty-five items across ideation, pre-production, production, post, and publishing, with the ten most-skipped steps and what each one costs when you skip it.
-- [Creator AI + CapCut: From AI Script to Subtitled, Dubbed Video](https://tryscriptai.com/blog/creator-ai-plus-capcut-youtube-workflow-2026): CapCut's auto-captions guess at your jargon. Generate the subtitle track separately, fix it once, then hand CapCut a clean SRT and keep its styling. Every click, including on mobile.
-- [Creator AI + Canva: Script to Thumbnail to Published in 30 Minutes](https://tryscriptai.com/blog/creator-ai-plus-canva-thumbnail-workflow-for-youtubers): Most creators write the video, then bolt on a thumbnail. Reversing that order is a real workflow improvement: your script's cold open is your thumbnail brief.
-- [Creator AI + ChatGPT: A Two-Tool Workflow for Video Ideas](https://tryscriptai.com/blog/creator-ai-plus-chatgpt-youtube-workflow-for-video-ideas): ChatGPT gives you 40 ideas anyone could have had. Here is the six-step handoff that turns them into three that fit your channel (with the exact prompts, copy-pasteable).
+- [The YouTube Video Production Checklist (45 Items, 5 Phases)](https://trycreatorai.com/blog/youtube-video-production-checklist-template): Forty-five items across ideation, pre-production, production, post, and publishing, with the ten most-skipped steps and what each one costs when you skip it.
+- [Creator AI + CapCut: From AI Script to Subtitled, Dubbed Video](https://trycreatorai.com/blog/creator-ai-plus-capcut-youtube-workflow-2026): CapCut's auto-captions guess at your jargon. Generate the subtitle track separately, fix it once, then hand CapCut a clean SRT and keep its styling. Every click, including on mobile.
+- [Creator AI + Canva: Script to Thumbnail to Published in 30 Minutes](https://trycreatorai.com/blog/creator-ai-plus-canva-thumbnail-workflow-for-youtubers): Most creators write the video, then bolt on a thumbnail. Reversing that order is a real workflow improvement: your script's cold open is your thumbnail brief.
+- [Creator AI + ChatGPT: A Two-Tool Workflow for Video Ideas](https://trycreatorai.com/blog/creator-ai-plus-chatgpt-youtube-workflow-for-video-ideas): ChatGPT gives you 40 ideas anyone could have had. Here is the six-step handoff that turns them into three that fit your channel (with the exact prompts, copy-pasteable).
 
 ### Audio Dubbing
 
-- [Is YouTube Dubbing Worth It? An Honest ROI Breakdown](https://tryscriptai.com/blog/is-youtube-dubbing-worth-it-roi-breakdown-2026): Every YouTube earnings calculator computes one number for one channel. None model the marginal revenue of adding a language, which is the decision you are actually trying to make.
-- [Best AI Dubbing Tool for YouTubers in 2026 (Compared)](https://tryscriptai.com/blog/best-ai-dubbing-tool-for-youtubers-2026-compared): We compared the top AI dubbing tools for creators on price, voice cloning, lip-sync, and languages, from YouTube's free auto-dub to ElevenLabs, HeyGen, Rask, and Creator AI.
-- [How Much Does AI Dubbing Cost in 2026? Real Prices vs Studio Dubbing](https://tryscriptai.com/blog/how-much-does-ai-dubbing-cost-vs-traditional-dubbing-2026): Published per-minute prices for seven AI dubbing tools, what a traditional studio actually quotes, the hidden line items nobody mentions, and the break-even math for a 10-minute video in five languages.
-- [YouTube Auto-Dubbing vs AI Voice Cloning: Why Your Dub Sounds Robotic](https://tryscriptai.com/blog/youtube-auto-dubbing-vs-ai-voice-cloning-explained): YouTube's free auto-dub gets your words into 27 languages, but it uses a stranger's voice, not yours. Here's why that quietly kills retention, and how voice cloning fixes it.
+- [Is YouTube Dubbing Worth It? An Honest ROI Breakdown](https://trycreatorai.com/blog/is-youtube-dubbing-worth-it-roi-breakdown-2026): Every YouTube earnings calculator computes one number for one channel. None model the marginal revenue of adding a language, which is the decision you are actually trying to make.
+- [Best AI Dubbing Tool for YouTubers in 2026 (Compared)](https://trycreatorai.com/blog/best-ai-dubbing-tool-for-youtubers-2026-compared): We compared the top AI dubbing tools for creators on price, voice cloning, lip-sync, and languages, from YouTube's free auto-dub to ElevenLabs, HeyGen, Rask, and Creator AI.
+- [How Much Does AI Dubbing Cost in 2026? Real Prices vs Studio Dubbing](https://trycreatorai.com/blog/how-much-does-ai-dubbing-cost-vs-traditional-dubbing-2026): Published per-minute prices for seven AI dubbing tools, what a traditional studio actually quotes, the hidden line items nobody mentions, and the break-even math for a 10-minute video in five languages.
+- [YouTube Auto-Dubbing vs AI Voice Cloning: Why Your Dub Sounds Robotic](https://trycreatorai.com/blog/youtube-auto-dubbing-vs-ai-voice-cloning-explained): YouTube's free auto-dub gets your words into 27 languages, but it uses a stranger's voice, not yours. Here's why that quietly kills retention, and how voice cloning fixes it.
 
 ### Subtitles
 
-- [SRT vs VTT: Subtitle Formats Explained (And When Each Breaks)](https://tryscriptai.com/blog/srt-vs-vtt-subtitle-formats-explained-2026): Two formats, one job, and a handful of differences that decide whether your captions render, style, or silently fail. Plus the six subtitle errors that cause most sync complaints.
-- [YouTube Auto Captions Are Wrong Where It Costs You Most](https://tryscriptai.com/blog/youtube-auto-captions-accuracy-how-to-fix-caption-errors-2026): Auto-captions hit 85 to 95% accuracy, and fail hardest on the exact words you want indexed. Here's a 10-minute audit that finds the errors and a workflow that stops them recurring.
-- [The Most Accurate AI Subtitle Generator? 7 Tools Tested on Real Accents](https://tryscriptai.com/blog/accurate-ai-subtitle-generator-for-youtube-tested-2026): Every subtitle tool is accurate on clean studio English. We tested seven on accents, jargon and music beds, the three places captions actually break, and measured the editing minutes each one cost.
-- [How Subtitles Increase YouTube Views and Watch Time](https://tryscriptai.com/blog/how-subtitles-boost-youtube-views-and-watch-time): Subtitles aren't just accessibility, they're a growth lever. Here's the data on why captions boost views, watch time, and global reach.
+- [SRT vs VTT: Subtitle Formats Explained (And When Each Breaks)](https://trycreatorai.com/blog/srt-vs-vtt-subtitle-formats-explained-2026): Two formats, one job, and a handful of differences that decide whether your captions render, style, or silently fail. Plus the six subtitle errors that cause most sync complaints.
+- [YouTube Auto Captions Are Wrong Where It Costs You Most](https://trycreatorai.com/blog/youtube-auto-captions-accuracy-how-to-fix-caption-errors-2026): Auto-captions hit 85 to 95% accuracy, and fail hardest on the exact words you want indexed. Here's a 10-minute audit that finds the errors and a workflow that stops them recurring.
+- [The Most Accurate AI Subtitle Generator? 7 Tools Tested on Real Accents](https://trycreatorai.com/blog/accurate-ai-subtitle-generator-for-youtube-tested-2026): Every subtitle tool is accurate on clean studio English. We tested seven on accents, jargon and music beds, the three places captions actually break, and measured the editing minutes each one cost.
+- [How Subtitles Increase YouTube Views and Watch Time](https://trycreatorai.com/blog/how-subtitles-boost-youtube-views-and-watch-time): Subtitles aren't just accessibility, they're a growth lever. Here's the data on why captions boost views, watch time, and global reach.
 
 ### Script Writing
 
-- [How to Write YouTube Hooks That Stop the Scroll (5 Frameworks)](https://tryscriptai.com/blog/how-to-write-youtube-hooks-that-stop-the-scroll): The first fifteen seconds decide whether the rest of your video gets watched. Five named hook frameworks, twenty fill-in-the-blank templates, and the test that predicts failure before you record.
-- [YouTube Shorts Script Generator: 5 Hooks That Stop the Scroll](https://tryscriptai.com/blog/youtube-shorts-script-generator-hooks-that-stop-the-scroll-2026): Short-form scripts fail in the first 1.5 seconds, not the last ten. Here is the beat structure Shorts actually reward, the five hook patterns that survive a swipe test, and what to demand from any tool that writes them for you.
-- [7 Best Free AI Script Generator Tools for YouTube (2026, Tested)](https://tryscriptai.com/blog/best-free-ai-script-generator-tools-for-youtube-videos-2026): Every free script tool advertises the same thing and hides the same limits. We ran seven of them on the same brief and compared output quality, real free-tier caps and what breaks the moment you need a second draft.
-- [How to Write YouTube Scripts That Get More Views](https://tryscriptai.com/blog/youtube-scripts-that-keep-viewers-watching): Learn the proven script structure top YouTubers use to hook viewers in the first 10 seconds and write YouTube scripts that get more views.
+- [How to Write YouTube Hooks That Stop the Scroll (5 Frameworks)](https://trycreatorai.com/blog/how-to-write-youtube-hooks-that-stop-the-scroll): The first fifteen seconds decide whether the rest of your video gets watched. Five named hook frameworks, twenty fill-in-the-blank templates, and the test that predicts failure before you record.
+- [YouTube Shorts Script Generator: 5 Hooks That Stop the Scroll](https://trycreatorai.com/blog/youtube-shorts-script-generator-hooks-that-stop-the-scroll-2026): Short-form scripts fail in the first 1.5 seconds, not the last ten. Here is the beat structure Shorts actually reward, the five hook patterns that survive a swipe test, and what to demand from any tool that writes them for you.
+- [7 Best Free AI Script Generator Tools for YouTube (2026, Tested)](https://trycreatorai.com/blog/best-free-ai-script-generator-tools-for-youtube-videos-2026): Every free script tool advertises the same thing and hides the same limits. We ran seven of them on the same brief and compared output quality, real free-tier caps and what breaks the moment you need a second draft.
+- [How to Write YouTube Scripts That Get More Views](https://trycreatorai.com/blog/youtube-scripts-that-keep-viewers-watching): Learn the proven script structure top YouTubers use to hook viewers in the first 10 seconds and write YouTube scripts that get more views.
 
 ### Tools & Roundups
 
-- [12 Best Free AI Tools for YouTube Creators (No Credit Card)](https://tryscriptai.com/blog/best-free-ai-tools-for-youtube-creators-2026): Most free tool lists lie. Half the entries are trials and the rest watermark your exports. Here is a truth-in-free-tier audit: what each one actually gives, what expires, and what needs a card.
-- [9 Best AI Tools to Turn Long Videos Into YouTube Shorts](https://tryscriptai.com/blog/best-ai-tools-to-turn-long-videos-into-shorts-2026): Every clipping comparison ranks tools on how they cut. None ask the better question: what makes a clip worth cutting? A clipper can only find a good moment if one exists.
-- [10 Best AI Tools for Faceless YouTube Channels (2026)](https://tryscriptai.com/blog/best-ai-tools-for-faceless-youtube-channels-2026): A faceless channel is a pipeline, not a tool stack. Organised by the eight stages of production, with the one advantage faceless creators have over everyone else, and almost nobody uses.
+- [12 Best Free AI Tools for YouTube Creators (No Credit Card)](https://trycreatorai.com/blog/best-free-ai-tools-for-youtube-creators-2026): Most free tool lists lie. Half the entries are trials and the rest watermark your exports. Here is a truth-in-free-tier audit: what each one actually gives, what expires, and what needs a card.
+- [9 Best AI Tools to Turn Long Videos Into YouTube Shorts](https://trycreatorai.com/blog/best-ai-tools-to-turn-long-videos-into-shorts-2026): Every clipping comparison ranks tools on how they cut. None ask the better question: what makes a clip worth cutting? A clipper can only find a good moment if one exists.
+- [10 Best AI Tools for Faceless YouTube Channels (2026)](https://trycreatorai.com/blog/best-ai-tools-for-faceless-youtube-channels-2026): A faceless channel is a pipeline, not a tool stack. Organised by the eight stages of production, with the one advantage faceless creators have over everyone else, and almost nobody uses.
 
 ### Alternatives
 
-- [7 Best Rask AI Alternatives for Video Dubbing (2026)](https://tryscriptai.com/blog/best-rask-ai-alternatives-for-video-dubbing-2026): Per-minute dubbing pricing punishes long-form creators. Here is what dubbing four 15-minute videos into three languages actually costs across seven tools, and which one fits a production workflow.
-- [8 Best TubeBuddy Alternatives in 2026 (Tested and Ranked)](https://tryscriptai.com/blog/best-tubebuddy-alternatives-for-youtube-creators-2026): Extension dependency, aggressive feature gating, a dated interface, and AI that arrived late. Eight alternatives ranked by what they actually replace, including the one feature that is genuinely hard to leave.
-- [9 Best vidIQ Alternatives for YouTube Creators (Free & Paid)](https://tryscriptai.com/blog/best-vidiq-alternatives-for-youtube-creators-2026): People leave vidIQ for four specific reasons: price creep, the AI credit ceiling, extension bloat, and scores that do not predict results. Here are nine alternatives, ranked honestly.
+- [7 Best Rask AI Alternatives for Video Dubbing (2026)](https://trycreatorai.com/blog/best-rask-ai-alternatives-for-video-dubbing-2026): Per-minute dubbing pricing punishes long-form creators. Here is what dubbing four 15-minute videos into three languages actually costs across seven tools, and which one fits a production workflow.
+- [8 Best TubeBuddy Alternatives in 2026 (Tested and Ranked)](https://trycreatorai.com/blog/best-tubebuddy-alternatives-for-youtube-creators-2026): Extension dependency, aggressive feature gating, a dated interface, and AI that arrived late. Eight alternatives ranked by what they actually replace, including the one feature that is genuinely hard to leave.
+- [9 Best vidIQ Alternatives for YouTube Creators (Free & Paid)](https://trycreatorai.com/blog/best-vidiq-alternatives-for-youtube-creators-2026): People leave vidIQ for four specific reasons: price creep, the AI credit ceiling, extension bloat, and scores that do not predict results. Here are nine alternatives, ranked honestly.
 
 ### Tool Comparisons
 
-- [Creator AI vs Descript: Script-First vs Edit-First Workflows](https://tryscriptai.com/blog/creator-ai-vs-descript-for-youtube-creators): Descript is a superb post-production tool. Creator AI works before the camera turns on. Most creators buy an editor to solve a writing problem. Here is how to tell which one you have.
-- [Creator AI vs Jasper for YouTube Scripts: Copy Is Not a Script](https://tryscriptai.com/blog/creator-ai-vs-jasper-for-youtube-scripts-2026): Jasper learns your writing. Creator AI learns your talking. Why an excellent marketing-copy platform produces blog prose in a script costume, and when Jasper is still the right call.
-- [vidIQ vs TubeBuddy (2026): We Ran Both on the Same Channel](https://tryscriptai.com/blog/vidiq-vs-tubebuddy-tested-on-the-same-channel-2026): We build a competing tool and have no affiliate deal with either. Here is what 30 days of running vidIQ and TubeBuddy side by side on one channel actually showed.
-- [Creator AI vs TubeBuddy: Optimization Tool vs Production Tool](https://tryscriptai.com/blog/creator-ai-vs-tubebuddy-for-youtube-creators): TubeBuddy optimizes videos you already made. Creator AI makes them. A fair comparison of two tools that are less competitive than the search results suggest.
-- [Creator AI vs vidIQ: Which One Actually Writes in Your Voice?](https://tryscriptai.com/blog/creator-ai-vs-vidiq-for-youtube-creators-2026): vidIQ tells you what the algorithm wants. Creator AI writes it the way you would have. An honest breakdown of where each one wins, and which to buy first if you can only afford one.
+- [Creator AI vs Descript: Script-First vs Edit-First Workflows](https://trycreatorai.com/blog/creator-ai-vs-descript-for-youtube-creators): Descript is a superb post-production tool. Creator AI works before the camera turns on. Most creators buy an editor to solve a writing problem. Here is how to tell which one you have.
+- [Creator AI vs Jasper for YouTube Scripts: Copy Is Not a Script](https://trycreatorai.com/blog/creator-ai-vs-jasper-for-youtube-scripts-2026): Jasper learns your writing. Creator AI learns your talking. Why an excellent marketing-copy platform produces blog prose in a script costume, and when Jasper is still the right call.
+- [vidIQ vs TubeBuddy (2026): We Ran Both on the Same Channel](https://trycreatorai.com/blog/vidiq-vs-tubebuddy-tested-on-the-same-channel-2026): We build a competing tool and have no affiliate deal with either. Here is what 30 days of running vidIQ and TubeBuddy side by side on one channel actually showed.
+- [Creator AI vs TubeBuddy: Optimization Tool vs Production Tool](https://trycreatorai.com/blog/creator-ai-vs-tubebuddy-for-youtube-creators): TubeBuddy optimizes videos you already made. Creator AI makes them. A fair comparison of two tools that are less competitive than the search results suggest.
+- [Creator AI vs vidIQ: Which One Actually Writes in Your Voice?](https://trycreatorai.com/blog/creator-ai-vs-vidiq-for-youtube-creators-2026): vidIQ tells you what the algorithm wants. Creator AI writes it the way you would have. An honest breakdown of where each one wins, and which to buy first if you can only afford one.
 
 ### YouTube Algorithm
 
-- [What the YouTube Algorithm Actually Rewards on a Small Channel](https://tryscriptai.com/blog/youtube-algorithm-for-small-channels-what-it-actually-rewards-2026): YouTube ranks videos, not channels, so why do yours stall? The gate isn't your subscriber count. It's the two signals you fully control, and most advice optimizes only half of one.
+- [What the YouTube Algorithm Actually Rewards on a Small Channel](https://trycreatorai.com/blog/youtube-algorithm-for-small-channels-what-it-actually-rewards-2026): YouTube ranks videos, not channels, so why do yours stall? The gate isn't your subscriber count. It's the two signals you fully control, and most advice optimizes only half of one.
 
 ### Video Ideas
 
-- [How to Build a YouTube Content Calendar That Survives a Bad Week](https://tryscriptai.com/blog/how-to-build-a-youtube-content-calendar-that-survives-2026): Most calendars die the first time life interferes. Here is how to build one with a real buffer, batch ideation feeding it, and slotting rules based on trend momentum rather than vibes.
-- [7 Best Spotter Studio Alternatives Under $50 a Month (2026)](https://tryscriptai.com/blog/best-spotter-studio-alternatives-for-youtube-ideation-2026): Spotter Studio is 49 USD a month, has no permanent free tier, and is built for channels with a team. Here are seven alternatives compared on ideation depth, outlier data, channel fit and price.
-- [YouTube Video Ideation: The 7-Step System That Beats Guessing](https://tryscriptai.com/blog/youtube-video-ideation-system-for-youtube-creators-2026): Most videos fail before the camera turns on, at the idea. Here is the 7-step ideation system that replaces brainstorming with evidence, and how to run it in minutes instead of hours.
-- [How to Find Trending YouTube Video Topics (Step-by-Step)](https://tryscriptai.com/blog/how-to-find-trending-youtube-video-topics-2026): Stop guessing what your audience wants. A step-by-step guide to finding trending YouTube topics with analytics, Google Trends, and AI.
+- [How to Build a YouTube Content Calendar That Survives a Bad Week](https://trycreatorai.com/blog/how-to-build-a-youtube-content-calendar-that-survives-2026): Most calendars die the first time life interferes. Here is how to build one with a real buffer, batch ideation feeding it, and slotting rules based on trend momentum rather than vibes.
+- [7 Best Spotter Studio Alternatives Under $50 a Month (2026)](https://trycreatorai.com/blog/best-spotter-studio-alternatives-for-youtube-ideation-2026): Spotter Studio is 49 USD a month, has no permanent free tier, and is built for channels with a team. Here are seven alternatives compared on ideation depth, outlier data, channel fit and price.
+- [YouTube Video Ideation: The 7-Step System That Beats Guessing](https://trycreatorai.com/blog/youtube-video-ideation-system-for-youtube-creators-2026): Most videos fail before the camera turns on, at the idea. Here is the 7-step ideation system that replaces brainstorming with evidence, and how to run it in minutes instead of hours.
+- [How to Find Trending YouTube Video Topics (Step-by-Step)](https://trycreatorai.com/blog/how-to-find-trending-youtube-video-topics-2026): Stop guessing what your audience wants. A step-by-step guide to finding trending YouTube topics with analytics, Google Trends, and AI.
 
 ### Thumbnails
 
-- [Best AI Thumbnail Maker in 2026: 17 Tools Tested on Real Uploads](https://tryscriptai.com/blog/best-ai-thumbnail-maker-tools-that-boost-youtube-ctr-2026): We ran 17 AI thumbnail tools on the same real uploads and tracked what happened to click-through rate. Here are the 7 that earned their place, what wasted money, and the workflow we kept.
-- [5 Thumbnail Mistakes Killing Your CTR (2026)](https://tryscriptai.com/blog/youtube-thumbnail-mistakes-killing-your-ctr-2026): Your video could be amazing, but a weak thumbnail means nobody clicks. Here are five common CTR mistakes, and how to fix them in 2026.
+- [Best AI Thumbnail Maker in 2026: 17 Tools Tested on Real Uploads](https://trycreatorai.com/blog/best-ai-thumbnail-maker-tools-that-boost-youtube-ctr-2026): We ran 17 AI thumbnail tools on the same real uploads and tracked what happened to click-through rate. Here are the 7 that earned their place, what wasted money, and the workflow we kept.
+- [5 Thumbnail Mistakes Killing Your CTR (2026)](https://trycreatorai.com/blog/youtube-thumbnail-mistakes-killing-your-ctr-2026): Your video could be amazing, but a weak thumbnail means nobody clicks. Here are five common CTR mistakes, and how to fix them in 2026.
 
 ### Creator AI vs Generic AI
 
-- [Creator AI vs Claude (2026): Which Wins for YouTube Creators?](https://tryscriptai.com/blog/creator-ai-vs-claude-for-youtube-creators): Claude is one of the best AI writers, but can it make a YouTube video? We compare Creator AI vs Claude on voice, retention, thumbnails, subtitles, and workflow.
-- [Best ChatGPT Alternatives for YouTubers in 2026 (Compared)](https://tryscriptai.com/blog/best-chatgpt-alternatives-for-youtubers-2026): ChatGPT wasn't built for YouTube. Compare the best ChatGPT alternatives for YouTubers, from voice-matched scripting to thumbnails, subtitles, and full workflows.
-- [Creator AI vs ChatGPT: Why Generic AI Falls Short for YouTube](https://tryscriptai.com/blog/creator-ai-vs-chatgpt-for-youtube-creators): You spent hours prompting ChatGPT for a script that sounds nothing like you. Here's how a dedicated YouTube AI tool compares on voice, retention, and full-video workflow.
-- [The AI That Learns Your Voice: Which Script Tools Actually Train on Your Videos](https://tryscriptai.com/blog/ai-script-tool-that-learns-your-voice-from-your-videos): Almost every AI writing tool claims it can match your tone. Only a few train on your actual uploads. Here is the difference, how the training works, and which tools really do it.
+- [Creator AI vs Claude (2026): Which Wins for YouTube Creators?](https://trycreatorai.com/blog/creator-ai-vs-claude-for-youtube-creators): Claude is one of the best AI writers, but can it make a YouTube video? We compare Creator AI vs Claude on voice, retention, thumbnails, subtitles, and workflow.
+- [Best ChatGPT Alternatives for YouTubers in 2026 (Compared)](https://trycreatorai.com/blog/best-chatgpt-alternatives-for-youtubers-2026): ChatGPT wasn't built for YouTube. Compare the best ChatGPT alternatives for YouTubers, from voice-matched scripting to thumbnails, subtitles, and full workflows.
+- [Creator AI vs ChatGPT: Why Generic AI Falls Short for YouTube](https://trycreatorai.com/blog/creator-ai-vs-chatgpt-for-youtube-creators): You spent hours prompting ChatGPT for a script that sounds nothing like you. Here's how a dedicated YouTube AI tool compares on voice, retention, and full-video workflow.
+- [The AI That Learns Your Voice: Which Script Tools Actually Train on Your Videos](https://trycreatorai.com/blog/ai-script-tool-that-learns-your-voice-from-your-videos): Almost every AI writing tool claims it can match your tone. Only a few train on your actual uploads. Here is the difference, how the training works, and which tools really do it.
 
 ### Growth
 
-- [How to Dub YouTube Videos Into Multiple Languages With AI (2026)](https://tryscriptai.com/blog/how-to-dub-youtube-videos-into-multiple-languages-ai): Reach global audiences without reshooting. Learn how AI dubbing works, which languages matter most, and how to grow a multilingual YouTube channel in 2026.
-- [How to Improve YouTube Audience Retention and Watch Time (2026)](https://tryscriptai.com/blog/improve-youtube-audience-retention-watch-time): Your retention graph tells you exactly where viewers leave. Learn how to read it, fix drop-off points, and use AI to write scripts that keep people watching.
+- [How to Dub YouTube Videos Into Multiple Languages With AI (2026)](https://trycreatorai.com/blog/how-to-dub-youtube-videos-into-multiple-languages-ai): Reach global audiences without reshooting. Learn how AI dubbing works, which languages matter most, and how to grow a multilingual YouTube channel in 2026.
+- [How to Improve YouTube Audience Retention and Watch Time (2026)](https://trycreatorai.com/blog/improve-youtube-audience-retention-watch-time): Your retention graph tells you exactly where viewers leave. Learn how to read it, fix drop-off points, and use AI to write scripts that keep people watching.
 
 ### AI & Creators
 
-- [How AI Is Changing YouTube Content Creation in 2026](https://tryscriptai.com/blog/ai-changing-content-creation-for-youtubers): In 2026, AI isn't experimental for YouTubers, it's table stakes. See how scripting, thumbnails, and research are changing, and how to adapt without losing your voice.
+- [How AI Is Changing YouTube Content Creation in 2026](https://trycreatorai.com/blog/ai-changing-content-creation-for-youtubers): In 2026, AI isn't experimental for YouTubers, it's table stakes. See how scripting, thumbnails, and research are changing, and how to adapt without losing your voice.
 
 ### Story Building
 
-- [Story Structure 101: Plan Videos That People Actually Finish](https://tryscriptai.com/blog/youtube-video-story-structure-for-retention-2026): Great videos aren't accidents. They follow a structure. Learn how to plan your video story so viewers stay engaged from start to finish.
+- [Story Structure 101: Plan Videos That People Actually Finish](https://trycreatorai.com/blog/youtube-video-story-structure-for-retention-2026): Great videos aren't accidents. They follow a structure. Learn how to plan your video story so viewers stay engaged from start to finish.

--- a/apps/web/scripts/generate-llms.mts
+++ b/apps/web/scripts/generate-llms.mts
@@ -19,7 +19,7 @@ import { config } from "dotenv";
 import { loadPublishedPosts } from "../lib/blog-source.ts";
 import type { BlogPost } from "../lib/blog-types.ts";
 
-const SITE = "https://tryscriptai.com";
+const SITE = "https://trycreatorai.com";
 const here = dirname(fileURLToPath(import.meta.url));
 const pub = resolve(here, "../public");
 
@@ -31,7 +31,7 @@ config({ path: resolve(here, "../../../.env") });
 const blogPosts = await loadPublishedPosts();
 
 // --- Static, human-curated site facts (entity clarity + E-E-A-T for AI) ------
-const HEADER = `# Creator AI (tryscriptai.com)
+const HEADER = `# Creator AI (trycreatorai.com)
 
 > Creator AI is an AI-powered production platform for YouTube creators. It learns
 > your voice from your existing videos and generates scripts, thumbnails,
@@ -48,7 +48,7 @@ fragmented stack (ChatGPT + Canva + subtitle tools) with one dashboard.
 
 - Website: ${SITE}
 - Product name: Creator AI
-- Also known as: Script AI, tryscriptai
+- Also known as: Script AI, tryscriptai.com (former domain, now redirects here)
 - Free tier: ${SITE}/signup (no credit card)
 
 ## Key Features

--- a/docs/aws-lightsail-hosting.md
+++ b/docs/aws-lightsail-hosting.md
@@ -4,7 +4,7 @@ This guide walks you through deploying CreatorAI (Next.js frontend + NestJS API 
 
 > **Why US East (us-east-1)?** It's AWS's largest, lowest-latency region for the bulk of US users (and fine for Canada/EU too), and US regions get the **full data-transfer allowance** — unlike Mumbai, which effectively halves it. If your users skew to the West Coast, pick **US West (Oregon, us-west-2)** instead; everything in this guide is identical, just swap the region name when you create the instance. Lightsail bundle pricing is the same across US regions. Your Vertex AI location stays `global`, so the region change doesn't affect generation.
 
-> **Prerequisites**: A domain name (e.g. tryscriptai.com), a Supabase project, your `.env` values ready, and a GCP service account JSON for Vertex AI.
+> **Prerequisites**: A domain name (e.g. trycreatorai.com), a Supabase project, your `.env` values ready, and a GCP service account JSON for Vertex AI.
 
 ---
 
@@ -105,8 +105,8 @@ Go to your domain registrar (Namecheap, GoDaddy, Cloudflare, etc.) and add these
 
 Wait for DNS propagation (usually 5–30 minutes, up to 48 hours).
 
-- `tryscriptai.com` → your frontend (Next.js)
-- `api.tryscriptai.com` → your backend (NestJS)
+- `trycreatorai.com` → your frontend (Next.js)
+- `api.trycreatorai.com` → your backend (NestJS)
 
 ---
 
@@ -204,11 +204,11 @@ REDIS_URL=redis://:abcd1234@redis:6379
 GOOGLE_APPLICATION_CREDENTIALS=/app/vertex-sa.json
 
 # Real domain (apps/web/.env)
-NEXT_PUBLIC_BACKEND_URL=https://api.tryscriptai.com
-NEXT_PUBLIC_BASE_URL=https://tryscriptai.com
+NEXT_PUBLIC_BACKEND_URL=https://api.trycreatorai.com
+NEXT_PUBLIC_BASE_URL=https://trycreatorai.com
 
 # Real domain + prod mode (apps/api/.env)
-FRONTEND_PROD_URL=https://tryscriptai.com
+FRONTEND_PROD_URL=https://trycreatorai.com
 NODE_ENV=production
 ```
 
@@ -231,7 +231,7 @@ Paste the **entire** JSON contents (copied from the file on your PC), then **Ctr
 > ✅ **You do not need to create these files.** `docker-compose.prod.yml`, `Dockerfile.web`, `Dockerfile.api`, `Dockerfile.worker`, and `Caddyfile` all ship in the repo. The sections below are kept for **reference only** so you know what each file does. Skip straight to **Part 10 — Build and Launch** unless you want to understand or customize them.
 >
 > Two things you *may* want to edit:
-> - `Caddyfile` — change `tryscriptai.com` to your domain if different.
+> - `Caddyfile` — change `trycreatorai.com` to your domain if different.
 > - `docker-compose.prod.yml` — the Redis password defaults to `abcd1234`; change it for production (and match it in your `REDIS_URL`).
 
 ### Reference: `docker-compose.prod.yml`
@@ -390,8 +390,21 @@ nano Caddyfile
 Paste:
 
 ```caddyfile
-tryscriptai.com, www.tryscriptai.com {
+trycreatorai.com, www.trycreatorai.com {
     reverse_proxy web:3000
+}
+
+api.trycreatorai.com {
+    reverse_proxy api:8000
+}
+```
+
+If you are migrating from an older domain, keep it pointed at the same static IP
+and add these two blocks so old links keep working (see the repo `Caddyfile`):
+
+```caddyfile
+tryscriptai.com, www.tryscriptai.com {
+    redir https://trycreatorai.com{uri} permanent
 }
 
 api.tryscriptai.com {
@@ -404,7 +417,7 @@ That's it. Caddy handles:
 - HTTP → HTTPS redirect
 - Certificate renewal
 
-> Replace `tryscriptai.com` with your actual domain if different.
+> Replace `trycreatorai.com` with your actual domain if different.
 
 ---
 
@@ -437,8 +450,8 @@ docker compose -f docker-compose.prod.yml logs caddy
 
 ### Test it
 
-- Open `https://tryscriptai.com` — you should see your app with a valid SSL certificate.
-- Open `https://api.tryscriptai.com` — should respond (or show a Nest welcome).
+- Open `https://trycreatorai.com` — you should see your app with a valid SSL certificate.
+- Open `https://api.trycreatorai.com` — should respond (or show a Nest welcome).
 
 ---
 

--- a/packages/email-templates/src/layout.ts
+++ b/packages/email-templates/src/layout.ts
@@ -3,11 +3,11 @@
 // on purpose: Outlook ignores <style> blocks, flexbox and most modern CSS.
 
 export const BRAND_NAME = 'Creator AI';
-export const BRAND_URL = 'https://tryscriptai.com';
+export const BRAND_URL = 'https://trycreatorai.com';
 
 // Transparent-background PNG, so it sits on the dark header band without the
 // black box the old asset had.
-export const LOGO_URL = 'https://tryscriptai.com/lighter%20email%20logo.png';
+export const LOGO_URL = 'https://trycreatorai.com/lighter%20email%20logo.png';
 
 const FONT_STACK =
   "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif";

--- a/packages/email-templates/src/merge-tags.ts
+++ b/packages/email-templates/src/merge-tags.ts
@@ -27,7 +27,7 @@ export const MERGE_TAGS: { tag: string; description: string; fallback: string }[
   { tag: 'planTier', description: 'Current plan (Starter, Creator, …)', fallback: 'Starter' },
   { tag: 'channelName', description: 'Connected channel name', fallback: 'your channel' },
   { tag: 'email', description: "Recipient's email address", fallback: '' },
-  { tag: 'unsubscribeUrl', description: 'Unsubscribe link', fallback: 'mailto:support@tryscriptai.com?subject=Unsubscribe' },
+  { tag: 'unsubscribeUrl', description: 'Unsubscribe link', fallback: 'mailto:support@trycreatorai.com?subject=Unsubscribe' },
 ];
 
 // Replaces every {{tag}} with the recipient's value (or the documented fallback).
@@ -39,7 +39,7 @@ export function resolveMergeTags(html: string, user: RecipientMergeData): string
     planTier: user.planTier || 'Starter',
     channelName: (user.channelConnected && user.channelName) || 'your channel',
     email: user.email,
-    unsubscribeUrl: user.unsubscribeUrl || 'mailto:support@tryscriptai.com?subject=Unsubscribe',
+    unsubscribeUrl: user.unsubscribeUrl || 'mailto:support@trycreatorai.com?subject=Unsubscribe',
   };
   return html.replace(/\{\{\s*(\w+)\s*\}\}/g, (match, tag: string) =>
     tag in values ? values[tag] : match,

--- a/packages/supabase/config.toml
+++ b/packages/supabase/config.toml
@@ -2,7 +2,7 @@
 # https://supabase.com/docs/guides/local-development/cli/config
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
-project_id = "scriptai"
+project_id = "creatorai"
 
 [api]
 enabled = true

--- a/packages/supabase/error-log.ts
+++ b/packages/supabase/error-log.ts
@@ -204,7 +204,7 @@ async function sendAlert(input: {
 
   try {
     await resend.emails.send({
-      from: 'Creator AI <notifications@tryscriptai.com>',
+      from: 'Creator AI <notifications@trycreatorai.com>',
       to: alertRecipient(),
       subject: `[Creator AI error] ${scope}: ${input.name} — ${input.message.slice(0, 90)}`,
       html: `<div style="font-family:Arial,sans-serif;color:#0f172a;background:#f8fafc;padding:20px;">

--- a/packages/supabase/migrations/20260822000000_domain_migration_trycreatorai.sql
+++ b/packages/supabase/migrations/20260822000000_domain_migration_trycreatorai.sql
@@ -1,0 +1,61 @@
+-- Domain move: tryscriptai.com -> trycreatorai.com.
+--
+-- The code-side fallbacks live in the repo, but some rows were seeded by earlier
+-- migrations and are edited from the admin dashboard, so they can only be moved
+-- here. A read-only scan of every public table found the old domain in six of
+-- them; three are live configuration and are rewritten below, three are
+-- historical records and are deliberately left alone:
+--
+--   REWRITTEN
+--   1. email_from_addresses.email      - the sender pool the composer offers.
+--   2. email_templates.html            - CTA links and the header logo <img>
+--      src. Email clients do not follow a 301 for an image, so a stale logo URL
+--      renders as a broken box in every campaign.
+--      email_templates.default_from_address - null everywhere today, but the
+--      dashboard can set it, and it holds a bare address with no FK to the
+--      sender pool, so renaming the pool alone could strand it.
+--   3. blog_posts.content              - absolute self-links. Matches 0 rows
+--      today; kept as a guard for posts edited before this deploys.
+--
+--   LEFT ALONE ON PURPOSE - do not "fix" these later
+--   - email_sends.from_address / .custom_html : the audit log of what was
+--     actually sent. Rewriting it would falsify the record.
+--   - funnel_events.referrer : raw analytics, stored verbatim from
+--     document.referrer and never parsed by host. Rewriting it would falsify
+--     where traffic actually came from.
+--   - mail_messages.body : inbound support mail. It is other people's words.
+--
+-- Every statement is a plain string replacement and idempotent: once no
+-- old-domain string remains, re-running changes nothing.
+
+-- 1. Sender pool. The unique index on email is why this is a guarded update
+-- rather than a blind one: if a previous run already inserted the new address,
+-- updating the old row onto it would raise 23505.
+update email_from_addresses a
+set email = replace(a.email, '@tryscriptai.com', '@trycreatorai.com')
+where a.email like '%@tryscriptai.com'
+  and not exists (
+    select 1 from email_from_addresses b
+    where b.email = replace(a.email, '@tryscriptai.com', '@trycreatorai.com')
+  );
+
+-- Drop any old-domain row that survived the guard because its new-domain twin
+-- already existed, so the composer stops offering a dead sender.
+delete from email_from_addresses
+where email like '%@tryscriptai.com';
+
+-- 2. Template bodies: CTA hrefs, both logo <img src> variants, support mailto.
+-- default_from_address moves in the same statement so a template can never end
+-- up pointing at a sender address that step 1 just renamed away.
+update email_templates
+set html = replace(html, 'tryscriptai.com', 'trycreatorai.com'),
+    default_from_address = replace(default_from_address, 'tryscriptai.com', 'trycreatorai.com'),
+    updated_at = now()
+where html like '%tryscriptai.com%'
+   or default_from_address like '%tryscriptai.com%';
+
+-- 3. Post bodies. Relative internal links are unaffected; this only catches
+-- absolute self-links, so they stop taking a 301 hop.
+update blog_posts
+set content = replace(content, 'tryscriptai.com', 'trycreatorai.com')
+where content like '%tryscriptai.com%';

--- a/packages/supabase/templates/confirmation.html
+++ b/packages/supabase/templates/confirmation.html
@@ -18,7 +18,7 @@
           <table role="presentation" cellpadding="0" cellspacing="0" border="0">
             <tr>
               <td style="padding-right:12px;vertical-align:middle;">
-                <img src="https://tryscriptai.com/lighter%20email%20logo.png" width="37" height="36" alt="" style="display:block;border:0;width:37px;height:36px;">
+                <img src="https://trycreatorai.com/lighter%20email%20logo.png" width="37" height="36" alt="" style="display:block;border:0;width:37px;height:36px;">
               </td>
               <td style="vertical-align:middle;color:#ffffff;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;font-size:19px;font-weight:700;letter-spacing:.4px;line-height:1;">
                 Creator AI

--- a/packages/ui/src/templates/emails/early-access.tsx
+++ b/packages/ui/src/templates/emails/early-access.tsx
@@ -30,7 +30,7 @@ const EarlyAccessEmail = () => {
             We'll email you once your access is ready. Get ready to create amazing content with Creator AI!
           </p>
           <a
-            href="https://v0-script-ai-app.vercel.app/"
+            href="https://trycreatorai.com/"
             target='_blank'
             className="inline-block bg-purple-600 text-white py-2 px-4 rounded-md font-semibold hover:bg-purple-700"
           >
@@ -45,8 +45,8 @@ const EarlyAccessEmail = () => {
           </p>
           <p className="text-gray-600 text-sm">
             Questions? Reach out to us at{' '}
-            <a href="mailto:support@tryscriptai.com" className="text-purple-600 hover:underline">
-              support@tryscriptai.com
+            <a href="mailto:support@trycreatorai.com" className="text-purple-600 hover:underline">
+              support@trycreatorai.com
             </a>
           </p>
         </div>

--- a/packages/validations/src/consts/http.ts
+++ b/packages/validations/src/consts/http.ts
@@ -1,4 +1,4 @@
-export const CREATOR_AI_USER_AGENT = 'CreatorAI/1.0 (+https://tryscriptai.com)';
+export const CREATOR_AI_USER_AGENT = 'CreatorAI/1.0 (+https://trycreatorai.com)';
 export const CREATOR_AI_CLIENT_HEADER = 'X-Creator-AI-Agent';
 
 export function mergeCreatorAiHeaders(headers?: HeadersInit): Headers {

--- a/packages/workers/src/processor/email-campaign.processor.ts
+++ b/packages/workers/src/processor/email-campaign.processor.ts
@@ -29,7 +29,7 @@ interface Recipient {
 
 function frontendBaseUrl(): string {
   return process.env.NODE_ENV === 'production'
-    ? process.env.FRONTEND_PROD_URL || 'https://tryscriptai.com'
+    ? process.env.FRONTEND_PROD_URL || 'https://trycreatorai.com'
     : process.env.FRONTEND_DEV_URL || 'http://localhost:3000';
 }
 

--- a/packages/workers/src/reminders/subscription-reminder.service.ts
+++ b/packages/workers/src/reminders/subscription-reminder.service.ts
@@ -123,7 +123,7 @@ export class SubscriptionReminderService {
     if (!this.resend) return;
     const baseUrl =
       process.env.NODE_ENV === 'production'
-        ? process.env.FRONTEND_PROD_URL || 'https://tryscriptai.com'
+        ? process.env.FRONTEND_PROD_URL || 'https://trycreatorai.com'
         : process.env.FRONTEND_DEV_URL || 'http://localhost:3000';
     const expiresOn = new Date(periodEnd).toLocaleDateString('en-US', {
       year: 'numeric',
@@ -138,7 +138,7 @@ export class SubscriptionReminderService {
     });
     try {
       await this.resend.emails.send({
-        from: 'Creator AI <no-reply@tryscriptai.com>',
+        from: 'Creator AI <no-reply@trycreatorai.com>',
         to,
         subject: `Your ${planName} plan expires in ${timeLeft}`,
         html,


### PR DESCRIPTION
Moves the product from `tryscriptai.com` to `trycreatorai.com`, across the web app, transactional and campaign email, the AEO/GEO surface, and the reverse proxy.

## Hardcoded fallbacks

Every `tryscriptai.com` fallback becomes `trycreatorai.com`, so a missing `NEXT_PUBLIC_BASE_URL` can no longer silently serve the old domain in canonicals, sitemap, robots, JSON-LD, or the `Server` header: `lib/seo.ts`, `app/sitemap.ts`, `app/robots.ts`, `lib/blog-seo-rules.ts`, `scripts/generate-llms.mts`, `email-templates/src/layout.ts`, `validations/src/consts/http.ts`, `next.config.mjs`, and both worker `FRONTEND_PROD_URL` fallbacks.

`webSiteJsonLd.sameAs` flips: the old domain is now declared as an alias of this one rather than the reverse.

## Three places that deliberately keep both domains

Not oversights, and each fails in a specific way if collapsed to one value:

- **`lib/blog-seo-rules.ts`** — the external-link check matches either domain. Posts written before the move link to themselves absolutely on the old domain; matching only the new one would make every such post read as having external links, and both `pnpm seo:audit` and the live check in the admin editor would start lying.
- **`api/webhook/resend/route.ts`** — the loop guard and support inbox are arrays now. Mail forwarded from the old support address still arrives addressed to it, so a single value would silently drop real support mail.
- **`Caddyfile`** — the old web host 301s with `{uri}` so path and query survive. The old **API** host is reverse-proxied rather than redirected: a browser drops a POST body across a 301 and blocks credentialed CORS requests that redirect, so any still-cached bundle pointing there would break.

## Email

Every sender, reply-to, and mailto moves to `@trycreatorai.com` now that the domain is verified in Resend. Also fixes the welcome email's hardcoded dashboard link and a stale `v0-script-ai-app.vercel.app` button in the early-access template.

`packages/supabase/templates/confirmation.html` is regenerated via `render:supabase`. **It still needs pasting into the Supabase dashboard** — the hosted project reads templates from there, not from the repo.

## Database migration

The sender pool and campaign template HTML were seeded by earlier migrations and are edited from the admin dashboard, so they can only move in a new migration; editing the historical migrations would change nothing in production. A read-only scan of all 40 public tables found the old domain in six:

| Table | Action |
|---|---|
| `email_from_addresses.email` | rewritten (3 rows, all active senders) |
| `email_templates.html` | rewritten (7 rows: both logo variants, CTAs, support mailto) |
| `email_templates.default_from_address` | rewritten in the same statement |
| `blog_posts.content` | 0 rows today; kept as a guard |
| `email_sends.from_address` / `.custom_html` | **left alone** — audit log of what was actually sent |
| `funnel_events.referrer` | **left alone** — raw analytics, stored verbatim, never parsed by host |
| `mail_messages.body` | **left alone** — inbound support mail |

`default_from_address` is the subtle one: it holds a bare address as plain `text` with **no FK** to the sender pool, so renaming the pool alone could strand a template pointing at an address that no longer exists. It's null on all 7 templates today, but the dashboard can set it.

The exclusions are documented in the migration header so nobody "fixes" the audit log later. Every statement is idempotent.

The email logo matters more than it looks: most clients will not follow a 301 for an image, so a stale logo URL renders as a broken box in every email rather than redirecting.

## Verification

- `tsc --noEmit` clean on web, api, workers, validations
- Affiliate service tests 11/11
- `pnpm seo:audit` — all 44 posts still pass
- `next build` compiles and generates all 115 pages
- Grepped the compiled `.next` bundle: exactly one old-domain occurrence survives, the intentional `sameAs` alias
- 25 old-domain references remain in tracked files, all accounted for: redirect blocks, the dual-domain guards, the "former domain" alias for answer engines, docs, and immutable historical migrations

## Deploy checklist

1. **`apps/api/.env` and `packages/workers/.env` need `FRONTEND_PROD_URL=https://trycreatorai.com`.** The API's CORS allowlist is built from that var alone, and the `"*"` in the array is a literal element, not a wildcard, so `includes()` never matches on it. A stale **or missing** value rejects every browser call from the new origin and takes the whole dashboard down. This is the one that bites.
2. `apps/web/.env` needs the new `NEXT_PUBLIC_*` values at **build** time, not runtime, so `docker compose build` — a restart is not enough.
3. Run the migration.
4. Paste the regenerated `confirmation.html` into Supabase → Authentication → Emails; set Site URL and add `https://trycreatorai.com/**` to the redirect allowlist.
5. Repoint the Resend inbound webhook to `https://trycreatorai.com/api/webhook/resend`.
6. Keep the old domain's A records on the same IP, or the Caddy redirect never fires.
7. `public/verify.html` is a Search Console token scoped to the old property; the new domain needs its own property and a change-of-address on the old one.
