### PR TITLE
chore(tsconfig): drop deprecated baseUrl, pin the editor to the repo TypeScript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  // Use the TypeScript the repo actually compiles with, not the newer one VS Code
+  // bundles. Without this the editor reports TS 6 deprecations (baseUrl,
+  // moduleResolution=node10) that no build in this repo produces, and the
+  // suggested fixes for them do not compile on TS 5.9.
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
+}

--- a/packages/typescript-config/nestjs.json
+++ b/packages/typescript-config/nestjs.json
@@ -8,6 +8,9 @@
     "forceConsistentCasingInFileNames": false,
     "incremental": true,
     "module": "commonjs",
+    // Deprecated in TS 6, removed in TS 7, but it cannot move yet: "bundler"
+    // needs TS >= 6 to pair with "commonjs" (TS5095 on 5.9), and node16/nodenext
+    // force "module" to match, which changes Nest's emit. Change with the TS upgrade.
     "moduleResolution": "Node10",
     "noFallthroughCasesInSwitch": false,
     "noImplicitAny": false,

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -14,7 +14,6 @@
     "declarationMap": true,
     "incremental": false,
     "target": "ES2022",
-    "baseUrl": ".",
     "paths": {
       "@repo/ui/*": ["./src/*"]
     }

--- a/packages/workers/tsconfig.json
+++ b/packages/workers/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@repo/typescript-config/nestjs.json",
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist"
   },
   "exclude": ["node_modules", "dist", "**/*.spec.ts"]


### PR DESCRIPTION
VS Code ships a newer TypeScript than this repo compiles with, so the editor reports TypeScript 6 deprecations that no build here produces. The repo is on TypeScript **5.9.3**; **7.0.2 is already `latest` on npm**, which is why the editor has run ahead.

Ran TypeScript 6.0.3 against every tsconfig to get the real list rather than guess:

| Config | Errors |
|---|---|
| `packages/workers/tsconfig.json` | `TS5101` baseUrl + `TS5107` moduleResolution=node10 |
| `packages/ui/tsconfig.json` | `TS5101` baseUrl |
| `apps/api/tsconfig.json` | `TS5107` moduleResolution=node10 (inherited from the shared Nest config) |

## What changed

**`baseUrl` removed** from `packages/ui` and `packages/workers`. This is what the [TS 6.0 notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html) ask for: make `paths` relative to the tsconfig instead. It is dead weight in both places, checked before deleting:

- `packages/ui` already writes `"@repo/ui/*": ["./src/*"]`. With `baseUrl: "."` pointing at the same directory, resolution is byte-identical without it.
- `packages/workers` has no `paths` at all, and no bare `src/…` specifiers that relied on baseUrl as a lookup root.

**`.vscode/settings.json`** points the editor at `node_modules/typescript`, so what it reports matches what actually compiles. `.gitignore` already un-ignores this file, so it is intended to be shared.

## What deliberately did not change

`moduleResolution: "Node10"` stays. **Every documented fix for it fails to compile on TypeScript 5.9**, verified:

```
"moduleResolution": "bundler"   → TS5095: 'bundler' can only be used when 'module'
                                  is set to 'preserve' or 'es2015' or later
"moduleResolution": "node16"    → TS5110: 'module' must be set to 'Node16'
"ignoreDeprecations": "6.0"     → TS5103: Invalid value for '--ignoreDeprecations'
```

`bundler` + `commonjs` is a pairing TypeScript 6.0 introduced, so it cannot land before the TS upgrade. `node16`/`nodenext` force `module` to match, which changes Nest's CommonJS emit. A comment in `nestjs.json` records this so the next person does not try it and break the build.

For the record, `bundler` **is** the right answer once TS 6 lands: I control-tested it and it produced an identical error count to `node10` under TS 6, so it is a clean swap at that point.

## Verification

- TypeScript 5.9.3: `apps/api`, `packages/workers`, `apps/web` all typecheck clean
- TypeScript 6.0.3: every `TS5101` gone; only the documented `TS5107` remains
- No behavior change — these are resolution-config edits with no emit impact

## Noted while testing, out of scope

- Under TS 6, `apps/api` has 9 pre-existing `TS2694: Namespace 'global.Express' has no exported member 'Multer'` errors. Invisible on 5.9.3, unrelated to this change, worth knowing before the TS 6 upgrade.
- The root `tsconfig.json` has no `include`/`exclude`, so it globs the whole monorepo and reports a flood of unrelated errors (`TS5097`, decorator errors from `apps/api`). No build uses it, and this PR does not change that, but a bare `tsc` at the root looks alarming for that reason.
