### PR TITLE
feat(onboarding): surface setup steps before the blocked click, not after

### DIFF
--- a/apps/web/app/dashboard/dubbing/new/page.tsx
+++ b/apps/web/app/dashboard/dubbing/new/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { Dialog, DialogContent, DialogTitle } from "@repo/ui/dialog";
 import { useDubbing } from "@/hooks/useDubbing";
+import { useAISetupGate } from "@/hooks/useAISetupGate";
 import { supportedLanguages, accentsFor } from "@repo/validation";
 import { downloadFile } from "@/lib/download";
 import { GenerationProgress, type GenerationProgressStep } from "@/components/dashboard/common/GenerationProgress";
@@ -122,11 +123,19 @@ export default function NewDubbing() {
   const [isDragging, setIsDragging] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
   const [showUpgrade, setShowUpgrade] = useState(false);
+  const gate = useAISetupGate();
 
-  // UI stays explorable; the plan gate fires on the Dub action. Server enforces authoritatively.
-  const locked = allowed === false;
+  // Two independent gates. Setup (channel + training) is checked first because
+  // that's the order the API enforces — OnboardedGuard runs before the plan and
+  // credit checks, so showing the upgrade card first would be a lie.
+  const planLocked = allowed === false;
+  const locked = gate.locked || planLocked;
   const handleGenerate = () => {
-    if (locked) {
+    if (gate.locked) {
+      gate.requestUnlock();
+      return;
+    }
+    if (planLocked) {
       setShowUpgrade(true);
       return;
     }
@@ -207,6 +216,8 @@ export default function NewDubbing() {
           </p>
         </div>
       </motion.div>
+
+      {gate.banner && <div className="mb-8">{gate.banner}</div>}
 
       {accessLoading ? (
         <motion.div variants={itemVariants} className="flex justify-center py-24">
@@ -435,7 +446,9 @@ export default function NewDubbing() {
                         className="w-full bg-purple-600 hover:bg-purple-700 text-white transition-all active:scale-[0.98]"
                         disabled={!locked && (!mediaFile || !targetLanguage || !mediaName.trim())}
                       >
-                        {locked ? (
+                        {gate.locked ? (
+                          <><Lock className="mr-2 h-4 w-4" /> {gate.step === "connect" ? "Connect your channel to dub" : "Train your AI to dub"}</>
+                        ) : planLocked ? (
                           <><Lock className="mr-2 h-4 w-4" /> Unlock audio dubbing</>
                         ) : (
                           <><Play className="mr-2 h-4 w-4" /> Dub {selectedLanguageLabel ? `to ${selectedLanguageLabel}` : "Media"}</>
@@ -456,6 +469,8 @@ export default function NewDubbing() {
           <DubbingUpgradeCard />
         </DialogContent>
       </Dialog>
+
+      {gate.modal}
     </motion.div>
   );
 }

--- a/apps/web/app/dashboard/research/new/page.tsx
+++ b/apps/web/app/dashboard/research/new/page.tsx
@@ -262,6 +262,8 @@ export default function NewIdeationPage() {
         </p>
       </div>
 
+      {gate.banner && <div className="mb-8">{gate.banner}</div>}
+
       <motion.div
         className="grid grid-cols-1 lg:grid-cols-12 gap-8 items-start"
         initial={{ opacity: 0 }}

--- a/apps/web/app/dashboard/scripts/new/page.tsx
+++ b/apps/web/app/dashboard/scripts/new/page.tsx
@@ -80,6 +80,8 @@ function NewScriptPageInner() {
         )}
       </div>
 
+      {gate.banner && <div className="mb-8">{gate.banner}</div>}
+
       <AnimatePresence mode="wait">
           {hook.showOutput ? (
             <motion.div

--- a/apps/web/app/dashboard/story-builder/new/page.tsx
+++ b/apps/web/app/dashboard/story-builder/new/page.tsx
@@ -66,6 +66,8 @@ export default function NewStoryBuilderPage() {
         )}
       </div>
 
+      {gate.banner && <div className="mb-8">{gate.banner}</div>}
+
       <AnimatePresence mode="wait">
           {hook.generatedResult ? (
             <motion.div

--- a/apps/web/app/dashboard/subtitles/new/page.tsx
+++ b/apps/web/app/dashboard/subtitles/new/page.tsx
@@ -11,10 +11,13 @@ import Link from "next/link";
 import { Button } from "@repo/ui/button";
 import { Badge } from "@repo/ui/badge";
 import { Skeleton } from "@repo/ui/skeleton";
+import { useAISetupGate } from "@/hooks/useAISetupGate";
 
 function NewSubtitlePageInner() {
     const searchParams = useSearchParams();
     const scriptId = searchParams.get("scriptId") ?? undefined;
+    // Banner only — the uploader owns the blocked-click modal, since it owns submit.
+    const gate = useAISetupGate();
 
     return (
         <div className="min-h-screen bg-[#f8fafc]">
@@ -45,6 +48,8 @@ function NewSubtitlePageInner() {
                         )}
                     </motion.div>
                 </div>
+
+                {gate.banner && <div className="mb-8">{gate.banner}</div>}
 
                 <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
                     <div className="lg:col-span-8 space-y-8">

--- a/apps/web/app/dashboard/thumbnails/new/page.tsx
+++ b/apps/web/app/dashboard/thumbnails/new/page.tsx
@@ -80,6 +80,8 @@ function NewThumbnailPageInner() {
         )}
       </div>
 
+      {gate.banner && <div className="mb-8">{gate.banner}</div>}
+
       <div className="max-w-full mx-auto">
           <AnimatePresence mode="wait">
             {showOutput ? (

--- a/apps/web/app/dashboard/video-generation/page.tsx
+++ b/apps/web/app/dashboard/video-generation/page.tsx
@@ -11,21 +11,29 @@ import { VideoHowItWorksGuide } from "@/components/dashboard/video-generation/Vi
 import { VideoUpgradeCard } from "@/components/dashboard/video-generation/VideoUpgradeCard"
 import { Button } from "@repo/ui/button"
 import { Dialog, DialogContent, DialogTitle } from "@repo/ui/dialog"
+import { useAISetupGate } from "@/hooks/useAISetupGate"
 
 export default function VideoGenerationPage() {
   const [allowed, setAllowed] = useState<boolean | null>(null)
   const [showUpgrade, setShowUpgrade] = useState(false)
   const vm = useVideoGeneration()
+  const gate = useAISetupGate()
 
   useEffect(() => {
     getVideoGenerationAccess().then((a) => setAllowed(a.allowed))
   }, [])
 
-  // UI is fully unlocked so everyone can explore the modes; the plan gate fires on
-  // Generate. The server still enforces the plan authoritatively regardless.
-  const locked = allowed === false
+  // UI is fully unlocked so everyone can explore the modes; the gates fire on
+  // Generate. Setup is checked before the plan because that's the order the API
+  // enforces. The server still enforces both authoritatively regardless.
+  const planLocked = allowed === false
+  const locked = gate.locked || planLocked
   const handleGenerate = async () => {
-    if (locked) {
+    if (gate.locked) {
+      gate.requestUnlock()
+      return
+    }
+    if (planLocked) {
       setShowUpgrade(true)
       return
     }
@@ -51,6 +59,8 @@ export default function VideoGenerationPage() {
         </Link>
       </div>
 
+      {gate.banner && <div className="mb-8">{gate.banner}</div>}
+
       <div className="mb-8">
         <VideoModeCards mode={vm.mode} onSelect={vm.setMode} locked={locked} disabled={vm.isGenerating} />
       </div>
@@ -71,6 +81,8 @@ export default function VideoGenerationPage() {
           <VideoUpgradeCard />
         </DialogContent>
       </Dialog>
+
+      {gate.modal}
     </div>
   )
 }

--- a/apps/web/components/dashboard/common/AISetupBanner.tsx
+++ b/apps/web/components/dashboard/common/AISetupBanner.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Youtube, Brain, ArrowRight, Loader2, Sparkles } from "lucide-react";
+import { useSupabase } from "@/components/supabase-provider";
+import { connectYoutubeChannel } from "@/lib/connectYT";
+
+export type SetupStep = "connect" | "train";
+
+/**
+ * Inline notice telling the user what setup this feature still needs, shown
+ * before they invest effort in a form they can't submit. Only ever surfaces the
+ * *next* step — connecting the channel, then training — because training is
+ * itself gated on a connected channel, so naming both at once is noise.
+ *
+ * Pairs with AISetupModal, which is the same information at the moment of the
+ * blocked click. Render this near the top of a feature page; render the modal once.
+ */
+export function AISetupBanner({ step }: { step: SetupStep }) {
+  const { supabase, user, profile } = useSupabase();
+  const [connecting, setConnecting] = useState(false);
+
+  const isConnect = step === "connect";
+  const Icon = isConnect ? Youtube : Brain;
+
+  const copy = isConnect
+    ? {
+        eyebrow: "Step 1 of 2",
+        title: "Connect your YouTube channel to use this feature",
+        body: "Linking your channel lets the AI learn your voice, style and niche. It takes about a minute.",
+        cta: "Connect channel",
+      }
+    : {
+        eyebrow: "Step 2 of 2",
+        title: "Train your AI to use this feature",
+        body: "Your channel is connected. Training builds your personal model so everything sounds like you.",
+        cta: "Start training",
+      };
+
+  return (
+    <div className="relative overflow-hidden rounded-2xl border border-purple-200/70 bg-gradient-to-br from-purple-50 via-white to-white p-5 sm:p-6 dark:border-purple-900/40 dark:from-purple-950/30 dark:via-slate-900 dark:to-slate-900">
+      <div className="pointer-events-none absolute -right-16 -top-16 h-48 w-48 rounded-full bg-purple-400/15 blur-3xl" />
+
+      <div className="relative z-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:gap-5">
+        <span className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-purple-600/10 text-purple-600 dark:bg-purple-500/15 dark:text-purple-300">
+          <Icon className="h-6 w-6" />
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <span className="text-[10px] font-black uppercase tracking-widest text-purple-600 dark:text-purple-400">
+            {copy.eyebrow}
+          </span>
+          <h3 className="mt-1 text-base font-bold text-slate-900 dark:text-slate-50">
+            {copy.title}
+          </h3>
+          <p className="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+            {copy.body}
+          </p>
+          {/* Free run is once per account and keyed off free_training_used, which
+              survives a disconnect — same source the dashboard onboarding uses. */}
+          {!isConnect && !profile?.free_training_used && (
+            <p className="mt-2 inline-flex items-center gap-1.5 text-sm font-semibold text-green-700 dark:text-green-400">
+              <Sparkles className="h-3.5 w-3.5" />
+              Your first training is free. No credits charged.
+            </p>
+          )}
+        </div>
+
+        {isConnect ? (
+          <button
+            onClick={() => connectYoutubeChannel({ supabase, user, setIsConnectingYoutube: setConnecting })}
+            disabled={connecting}
+            className="inline-flex w-full shrink-0 items-center justify-center gap-2 rounded-xl bg-purple-600 px-5 py-3 text-sm font-semibold text-white transition-all hover:bg-purple-700 active:scale-[0.98] disabled:opacity-60 sm:w-auto"
+          >
+            {connecting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <>
+                {copy.cta} <ArrowRight className="h-4 w-4" />
+              </>
+            )}
+          </button>
+        ) : (
+          <Link
+            href="/dashboard/train"
+            className="inline-flex w-full shrink-0 items-center justify-center gap-2 rounded-xl bg-purple-600 px-5 py-3 text-sm font-semibold text-white transition-all hover:bg-purple-700 active:scale-[0.98] sm:w-auto"
+          >
+            {copy.cta} <ArrowRight className="h-4 w-4" />
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/subtitles/subtitleUploader.tsx
+++ b/apps/web/components/dashboard/subtitles/subtitleUploader.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import * as motion from "motion/react-m";
 import axios from "axios";
-import { UploadCloud, Loader2, Zap } from "lucide-react";
+import { UploadCloud, Loader2, Zap, Lock } from "lucide-react";
 import { toast } from "sonner";
 
 // UI Components
@@ -16,6 +16,7 @@ import { Label } from "@repo/ui/label";
 // Hooks & Utils
 import { api, getApiErrorMessage } from "@/lib/api-client";
 import { formatUploadLimit, SUBTITLE_PAID_UPLOAD_BYTES, SUBTITLE_PAID_MAX_DURATION_SECONDS } from "@repo/validation";
+import { useAISetupGate } from "@/hooks/useAISetupGate";
 
 type SubtitleUploaderProps = {
     onUploadSuccess: () => void;
@@ -23,6 +24,7 @@ type SubtitleUploaderProps = {
 };
 
 export function SubtitleUploader({ onUploadSuccess, scriptId }: SubtitleUploaderProps) {
+    const gate = useAISetupGate();
     const [file, setFile] = useState<File | null>(null);
     const [title, setTitle] = useState("");
     const [duration, setDuration] = useState<number | null>(null);
@@ -79,6 +81,10 @@ export function SubtitleUploader({ onUploadSuccess, scriptId }: SubtitleUploader
 
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
+        // Setup gate first — the API checks OnboardedGuard before the plan and
+        // upload limits, so a blocked user should see the setup modal, not a
+        // signed-URL failure after picking a file.
+        if (gate.locked) return gate.requestUnlock();
         if (!file || !duration) return toast.warning("Please select a valid file.");
 
         setIsUploading(true);
@@ -227,10 +233,17 @@ export function SubtitleUploader({ onUploadSuccess, scriptId }: SubtitleUploader
 
                     <Button
                         type="submit"
-                        disabled={!file || !duration || isUploading}
+                        // Stays clickable while gated so the modal can explain why,
+                        // rather than leaving a dead button with no feedback.
+                        disabled={!gate.locked && (!file || !duration || isUploading)}
                         className="w-full sm:w-auto bg-slate-900 hover:bg-slate-800 text-white px-10 h-12 rounded-xl text-base font-bold shadow-lg shadow-slate-200 transition-all active:scale-95"
                     >
-                        {isUploading ? (
+                        {gate.locked ? (
+                            <>
+                                <Lock className="mr-2 h-4 w-4" />
+                                {gate.step === "connect" ? "Connect your channel first" : "Train your AI first"}
+                            </>
+                        ) : isUploading ? (
                             <>
                                 <Loader2 className="mr-2 h-5 w-5 animate-spin" />
                                 {progress > 0 && progress < 100 ? `Uploading ${progress}%` : "Processing..."}
@@ -239,6 +252,8 @@ export function SubtitleUploader({ onUploadSuccess, scriptId }: SubtitleUploader
                     </Button>
                 </div>
             </form>
+
+            {gate.modal}
         </Card>
     );
 }

--- a/apps/web/hooks/useAISetupGate.tsx
+++ b/apps/web/hooks/useAISetupGate.tsx
@@ -3,21 +3,36 @@
 import { useState } from "react";
 import { useSupabase } from "@/components/supabase-provider";
 import { AISetupModal } from "@/components/dashboard/common/AISetupModal";
+import { AISetupBanner, type SetupStep } from "@/components/dashboard/common/AISetupBanner";
 
 /**
  * Gate for generation actions. `locked` is true until the user has connected a
- * YouTube channel AND trained their AI. Render `modal` once in the page and wire
- * `requestUnlock` to the generate button's onClick when locked.
+ * YouTube channel AND trained their AI.
+ *
+ * Two surfaces, same state:
+ * - `banner` — render near the top of the page so the user learns what's missing
+ *   *before* filling in a form they can't submit.
+ * - `modal` — render once and wire `requestUnlock` to the generate button, for
+ *   the user who goes ahead and clicks anyway.
+ *
+ * Both show only the next actionable step: training is itself gated on a
+ * connected channel, so asking for both at once just makes the first one unclear.
  */
 export function useAISetupGate() {
   const { profile } = useSupabase();
   const [open, setOpen] = useState(false);
 
-  const locked = !(profile?.youtube_connected === true && profile?.ai_trained === true);
+  const connected = profile?.youtube_connected === true;
+  const trained = profile?.ai_trained === true;
+  const locked = !(connected && trained);
+
+  const step: SetupStep | null = !connected ? "connect" : !trained ? "train" : null;
 
   return {
     locked,
+    step,
     requestUnlock: () => setOpen(true),
+    banner: step ? <AISetupBanner step={step} /> : null,
     modal: <AISetupModal open={open} onOpenChange={setOpen} />,
   };
 }


### PR DESCRIPTION
## Why

Every credit-spending feature is gated on a connected YouTube channel **and** a trained AI, but the gate was invisible until submit.

On dubbing that meant: name the media → upload a file → pick a language → hit **Dub** → raw 403 from `sign-upload`. Maximum effort, then a wall. Checking `error_logs`, both users who hit it left within three minutes of signing up, having never produced a dub.

This doesn't change the gate. It just tells people about it before they do the work.

## What

Two surfaces backed by one piece of state in `useAISetupGate`:

- **`AISetupBanner`** (new) — renders near the top of the page, before the user invests effort in a form they can't submit.
- **`AISetupModal`** (existing) — still handles the blocked click for anyone who proceeds anyway.

Both show only the **next actionable step**. Training is itself gated on a connected channel, so asking for both at once makes the first one ambiguous:

| Profile state | Shown |
|---|---|
| No channel | "Connect your YouTube channel" → inline OAuth |
| Channel, not trained | "Train your AI" → `/dashboard/train` |
| Both done | nothing renders |

The train step also carries the *"first training is free, no credits charged"* line from the dashboard onboarding, keyed off `free_training_used`.

## Coverage

| Page | Banner | Modal |
|---|---|---|
| `dubbing/new`, `video-generation`, `subtitles/new` | added | **added** — had none |
| `scripts`, `thumbnails`, `research`, `story-builder` | added | already had |

The hook keeps its existing `locked` / `requestUnlock` / `modal` API, so the four pages already using it needed nothing beyond dropping the banner in.

## Two decisions worth reviewing

**Gate ordering.** On dubbing and video-generation a *plan* gate already existed with its own upgrade dialog. Setup is now checked **first**, because `OnboardedGuard` runs ahead of the plan and credit checks — leading with an upgrade card would show a reason that isn't the reason the request would actually fail. Button labels name the real blocker ("Connect your channel to dub" / "Train your AI to dub" / "Unlock audio dubbing").

**Subtitles intercepts in `SubtitleUploader`**, which owns submit, rather than drilling props through the page. Its button stays *enabled* while gated so the click opens the modal — a disabled button gives no feedback, which is the problem this PR exists to fix.

## Risk

Frontend only. No API or gating behaviour changes; the server still enforces everything authoritatively.

## Testing

`tsc --noEmit` passes clean on `apps/web`.

⚠️ **Not verified in a running browser** — this needs auth plus a profile in each gate state. Worth a manual pass on `/dashboard/dubbing/new` with an untrained account, and one with a connected-but-untrained account, before merging.
