### PR TITLE
feat(tools): free story structure generator, and keep every free run

### DIFF
--- a/apps/api/src/free-tools/free-tool-runs.service.spec.ts
+++ b/apps/api/src/free-tools/free-tool-runs.service.spec.ts
@@ -1,0 +1,136 @@
+import { scriptRow, ideaRow, storyRow } from './free-tool-runs.service';
+
+/**
+ * The row builders are the part of the claim that can fail silently: they turn
+ * an anonymous run into a row in a table the dashboard renders, and a missing
+ * field shows up as an empty panel on a page the user just signed up to see,
+ * not as an error anyone notices.
+ *
+ * NOW is fixed so the assertions are about mapping, not about the clock.
+ */
+const NOW = '2026-09-06T12:00:00.000Z';
+const USER = 'user-1';
+
+describe('claiming a free script', () => {
+  const output = { title: 'Why your espresso tastes sour', script: '## Hook\nStop.' };
+
+  it('lands as a completed script with the generated content', () => {
+    const row = scriptRow(USER, { topic: 'espresso', tone: 'funny', duration: 300 }, output, NOW);
+    expect(row.user_id).toBe(USER);
+    expect(row.title).toBe(output.title);
+    expect(row.content).toBe(output.script);
+    expect(row.status).toBe('completed');
+  });
+
+  it('costs no credits: the generation was already free', () => {
+    expect(scriptRow(USER, { topic: 'espresso' }, output, NOW).credits_consumed).toBe(0);
+  });
+
+  it('carries the visitor’s own tone and duration rather than the defaults', () => {
+    const row = scriptRow(USER, { topic: 'espresso', tone: 'funny', duration: 300 }, output, NOW);
+    expect(row.tone).toBe('funny');
+    expect(row.duration).toBe(300);
+  });
+
+  it('never writes an empty title, which would render as a blank history row', () => {
+    const row = scriptRow(USER, { topic: 'espresso' }, { title: '', script: 'x' }, NOW);
+    expect(row.title).toBe('espresso');
+    expect(scriptRow(USER, {}, { title: '', script: '' }, NOW).title).toBe('Untitled script');
+  });
+});
+
+describe('claiming a free idea', () => {
+  const output = {
+    title: 'Sour espresso, fixed',
+    titleVariations: ['a', 'b'],
+    uniqueAngle: 'angle',
+    whyItWorks: 'because',
+    hookAngle: 'hook',
+    suggestedFormat: 'Tutorial',
+    targetKeywords: ['espresso'],
+    talkingPoints: ['one', 'two'],
+    opportunityScore: 72,
+  };
+
+  it('wraps the single idea in the ideas[] the dashboard reads', () => {
+    const row = ideaRow(USER, { niche: 'home espresso' }, output, NOW);
+    expect(row.result.ideas).toHaveLength(1);
+    expect(row.result.ideas[0]!.title).toBe(output.title);
+    expect(row.idea_count).toBe(1);
+    expect(row.status).toBe('completed');
+  });
+
+  it('fills the fields the free generator has no channel to derive', () => {
+    const idea = ideaRow(USER, { niche: 'home espresso' }, output, NOW).result.ideas[0]!;
+    // IdeaCard prints trendMomentum as text; undefined renders an empty badge.
+    expect(idea.trendMomentum).toBe('stable');
+    expect(idea.coreTopic).toBe('home espresso');
+    expect(idea.referenceSignals).toEqual([]);
+    expect(idea.id).toBeTruthy();
+  });
+
+  it('omits trendSnapshot and channelFit, which need a connected channel', () => {
+    const row = ideaRow(USER, { niche: 'home espresso' }, output, NOW);
+    expect(row.result).not.toHaveProperty('trendSnapshot');
+    expect(row.result).not.toHaveProperty('channelFit');
+  });
+
+  it('survives a generation that came back missing array fields', () => {
+    const idea = ideaRow(USER, {}, {} as never, NOW).result.ideas[0]!;
+    // The dashboard maps over all three without guarding.
+    expect(idea.titleVariations).toEqual([]);
+    expect(idea.targetKeywords).toEqual([]);
+    expect(idea.talkingPoints).toEqual([]);
+  });
+});
+
+describe('claiming a free story blueprint', () => {
+  const blueprint = { structuredBlueprint: { hook: {} }, tensionMapping: { retentionScore: 8 } };
+
+  it('stores the blueprint verbatim, so the dashboard renders every section', () => {
+    const row = storyRow(
+      USER,
+      {
+        videoTopic: 'espresso',
+        videoDuration: 'long',
+        contentType: 'case_study',
+        storyMode: 'documentary',
+        audienceLevel: 'beginner',
+      },
+      blueprint,
+      NOW,
+    );
+    expect(row.result).toBe(blueprint);
+    expect(row.video_topic).toBe('espresso');
+    expect(row.status).toBe('completed');
+    expect(row.credits_consumed).toBe(0);
+  });
+
+  it('keeps the structural choices the visitor made on the public page', () => {
+    const row = storyRow(
+      USER,
+      {
+        videoTopic: 'espresso',
+        videoDuration: 'long',
+        contentType: 'case_study',
+        storyMode: 'documentary',
+        audienceLevel: 'beginner',
+      },
+      blueprint,
+      NOW,
+    );
+    expect(row.video_duration).toBe('long');
+    expect(row.content_type).toBe('case_study');
+    expect(row.story_mode).toBe('documentary');
+    expect(row.audience_level).toBe('beginner');
+  });
+
+  it('falls back to the same defaults the paid form uses', () => {
+    const row = storyRow(USER, { videoTopic: 'espresso' }, blueprint, NOW);
+    expect(row.video_duration).toBe('medium');
+    expect(row.content_type).toBe('tutorial');
+    expect(row.story_mode).toBe('conversational');
+    expect(row.audience_level).toBe('general');
+    expect(row.target_audience).toBeNull();
+  });
+});

--- a/apps/api/src/free-tools/free-tool-runs.service.ts
+++ b/apps/api/src/free-tools/free-tool-runs.service.ts
@@ -1,0 +1,237 @@
+import { Injectable, Logger, NotFoundException, InternalServerErrorException } from '@nestjs/common';
+import type { IdeationIdea } from '@repo/validation';
+import { SupabaseService } from '../supabase/supabase.service';
+import type { FreeIdea, FreeScript } from './free-tools.service';
+
+/**
+ * Keeps anonymous /tools generations, and hands them to the account created
+ * afterwards.
+ *
+ * Two halves:
+ *   record() — called after every free generation, best-effort. A DB hiccup
+ *              must never turn a working generator into an error page, so a
+ *              failed write is logged and swallowed; the visitor still sees
+ *              their result, they just cannot claim it later.
+ *   claim()  — called once from the dashboard after signup. Copies the stored
+ *              run into the real feature table so the user lands on a normal
+ *              record with normal history, not a special "imported" one.
+ *
+ * The session id is the authorization: run ids travel in URLs, session ids do
+ * not, so a claim must present both.
+ */
+
+export type FreeToolName = 'script' | 'idea' | 'story';
+
+/** Where each tool's run materializes, and what the dashboard route is. */
+const TARGET: Record<FreeToolName, { table: string; route: string }> = {
+  script: { table: 'scripts', route: '/dashboard/scripts' },
+  idea: { table: 'ideation_jobs', route: '/dashboard/research' },
+  story: { table: 'story_builder_jobs', route: '/dashboard/story-builder' },
+};
+
+export interface ClaimResult {
+  tool: FreeToolName;
+  recordId: string;
+  /** Ready-to-push dashboard path for the materialized record. */
+  redirectTo: string;
+}
+
+@Injectable()
+export class FreeToolRunsService {
+  private readonly logger = new Logger(FreeToolRunsService.name);
+
+  constructor(private readonly supabaseService: SupabaseService) {}
+
+  private get db() {
+    return this.supabaseService.getClient();
+  }
+
+  /**
+   * Store one anonymous run. Returns the run id, or null when the write failed.
+   * Never throws: the generation already succeeded and the visitor is looking
+   * at it.
+   */
+  async record(
+    sessionId: string,
+    tool: FreeToolName,
+    input: Record<string, unknown>,
+    output: unknown,
+  ): Promise<string | null> {
+    try {
+      const { data, error } = await this.db
+        .from('free_tool_runs')
+        .insert({ session_id: sessionId, tool, input, output })
+        .select('id')
+        .single();
+
+      if (error || !data) {
+        this.logger.warn(`free_tool_runs insert failed (${tool}): ${error?.message ?? 'no row'}`);
+        return null;
+      }
+      return data.id as string;
+    } catch (error) {
+      this.logger.warn(`free_tool_runs insert threw (${tool}): ${(error as Error).message}`);
+      return null;
+    }
+  }
+
+  /**
+   * Materialize one stored run into the real feature table for `userId`.
+   *
+   * Idempotent: a run already claimed by this user returns the record it
+   * created rather than inserting a second copy, so a refresh of the dashboard
+   * URL that carries `?freeRun=` is harmless.
+   */
+  async claim(runId: string, sessionId: string, userId: string): Promise<ClaimResult> {
+    const { data: run, error } = await this.db
+      .from('free_tool_runs')
+      .select('id, tool, input, output, claimed_by, claimed_record_id')
+      .eq('id', runId)
+      .eq('session_id', sessionId)
+      .maybeSingle();
+
+    // Same 404 for "no such run" and "wrong session": a claim endpoint that
+    // distinguishes them is a probe for which run ids exist.
+    if (error || !run) throw new NotFoundException('That free result is no longer available.');
+
+    const tool = run.tool as FreeToolName;
+
+    if (run.claimed_by) {
+      if (run.claimed_by !== userId) {
+        throw new NotFoundException('That free result is no longer available.');
+      }
+      return this.toResult(tool, run.claimed_record_id as string);
+    }
+
+    const recordId = await this.materialize(tool, userId, run.input ?? {}, run.output ?? {});
+
+    const { error: markError } = await this.db
+      .from('free_tool_runs')
+      .update({
+        claimed_by: userId,
+        claimed_at: new Date().toISOString(),
+        claimed_record_id: recordId,
+      })
+      .eq('id', runId)
+      // Only claim a run nobody else has taken in the meantime.
+      .is('claimed_by', null);
+
+    if (markError) {
+      // The real row exists and is the thing the user asked for, so this is a
+      // bookkeeping failure, not a user-facing one. Worst case the run stays
+      // claimable and a second claim inserts a duplicate they can delete.
+      this.logger.warn(`free_tool_runs claim mark failed for ${runId}: ${markError.message}`);
+    }
+
+    return this.toResult(tool, recordId);
+  }
+
+  private toResult(tool: FreeToolName, recordId: string): ClaimResult {
+    return { tool, recordId, redirectTo: `${TARGET[tool].route}/${recordId}` };
+  }
+
+  private async materialize(
+    tool: FreeToolName,
+    userId: string,
+    input: Record<string, any>,
+    output: any,
+  ): Promise<string> {
+    const now = new Date().toISOString();
+    // Every claimed row is free by definition: the generation was already paid
+    // for by us, not by the user's credits.
+    const row =
+      tool === 'script'
+        ? scriptRow(userId, input, output as FreeScript, now)
+        : tool === 'idea'
+          ? ideaRow(userId, input, output as FreeIdea, now)
+          : storyRow(userId, input, output, now);
+
+    const { data, error } = await this.db
+      .from(TARGET[tool].table)
+      .insert(row)
+      .select('id')
+      .single();
+
+    if (error || !data) {
+      this.logger.error(`${TARGET[tool].table} insert failed on claim: ${error?.message}`);
+      throw new InternalServerErrorException('Could not save that result to your account.');
+    }
+    return data.id as string;
+  }
+
+}
+
+export function scriptRow(userId: string, input: Record<string, any>, output: FreeScript, now: string) {
+  return {
+    user_id: userId,
+    title: output?.title || input.topic || 'Untitled script',
+    content: output?.script ?? '',
+    prompt: input.topic ?? '',
+    tone: input.tone ?? 'conversational',
+    language: 'English',
+    duration: input.duration ?? 180,
+    include_storytelling: !!input.includeStorytelling,
+    include_timestamps: !!input.includeTimestamps,
+    status: 'completed',
+    credits_consumed: 0,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+/**
+ * The free generator returns one idea with a slightly narrower shape than the
+ * paid one (no channel to derive coreTopic, reference signals or momentum
+ * from). Fill those in rather than leaving them undefined: IdeaCard renders
+ * `trendMomentum` as text and would print an empty badge.
+ */
+export function ideaRow(userId: string, input: Record<string, any>, output: FreeIdea, now: string) {
+  const idea: IdeationIdea = {
+    id: `free-${Date.now()}`,
+    title: output?.title ?? '',
+    titleVariations: output?.titleVariations ?? [],
+    coreTopic: input.niche ?? output?.title ?? '',
+    uniqueAngle: output?.uniqueAngle ?? '',
+    whyItWorks: output?.whyItWorks ?? '',
+    hookAngle: output?.hookAngle ?? '',
+    targetKeywords: output?.targetKeywords ?? [],
+    suggestedFormat: output?.suggestedFormat ?? '',
+    talkingPoints: output?.talkingPoints ?? [],
+    referenceSignals: [],
+    searchIntentSummary: '',
+    opportunityScore: output?.opportunityScore ?? 0,
+    trendMomentum: 'stable',
+  };
+
+  return {
+    user_id: userId,
+    niche_focus: input.niche ?? null,
+    context: input.audience || null,
+    idea_count: 1,
+    auto_mode: false,
+    status: 'completed',
+    credits_consumed: 0,
+    // trendSnapshot and channelFit are deliberately absent: both need a
+    // connected channel, and the dashboard already guards on them.
+    result: { ideas: [idea], metadata: { generatedAt: now, creditsConsumed: 0, totalTokens: 0 } },
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+export function storyRow(userId: string, input: Record<string, any>, output: any, now: string) {
+  return {
+    user_id: userId,
+    video_topic: input.videoTopic ?? '',
+    target_audience: input.targetAudience || null,
+    audience_level: input.audienceLevel ?? 'general',
+    video_duration: input.videoDuration ?? 'medium',
+    content_type: input.contentType ?? 'tutorial',
+    story_mode: input.storyMode ?? 'conversational',
+    status: 'completed',
+    credits_consumed: 0,
+    result: output,
+    created_at: now,
+    updated_at: now,
+  };
+}

--- a/apps/api/src/free-tools/free-tools.controller.spec.ts
+++ b/apps/api/src/free-tools/free-tools.controller.spec.ts
@@ -2,9 +2,15 @@ import { allowRequest } from '../common/rate-limit';
 import {
   IdeaSchema,
   ScriptSchema,
+  StorySchema,
+  ClaimSchema,
   WINDOW_MS,
   MAX_PER_WINDOW,
 } from './free-tools.controller';
+
+// Every free generation now carries the visitor's localStorage session id, so
+// the run can be handed to the account they create afterwards.
+const SESSION = '11111111-2222-4333-8444-555555555555';
 
 describe('free tools rate limit', () => {
   it('allows MAX_PER_WINDOW generations per IP, then blocks until the window rolls', () => {
@@ -35,26 +41,61 @@ describe('free tools rate limit', () => {
 
 describe('free tools input validation', () => {
   it('rejects an empty or too-short niche', () => {
-    expect(IdeaSchema.safeParse({ niche: '' }).success).toBe(false);
-    expect(IdeaSchema.safeParse({ niche: 'ab' }).success).toBe(false);
-    expect(IdeaSchema.safeParse({ niche: 'home espresso' }).success).toBe(true);
+    expect(IdeaSchema.safeParse({ sessionId: SESSION, niche: '' }).success).toBe(false);
+    expect(IdeaSchema.safeParse({ sessionId: SESSION, niche: 'ab' }).success).toBe(false);
+    expect(IdeaSchema.safeParse({ sessionId: SESSION, niche: 'home espresso' }).success).toBe(true);
   });
 
   it('caps the free script well under the paid feature range', () => {
-    expect(ScriptSchema.safeParse({ topic: 'espresso', duration: 1200 }).success).toBe(false);
-    expect(ScriptSchema.safeParse({ topic: 'espresso', duration: 30 }).success).toBe(false);
+    expect(ScriptSchema.safeParse({ sessionId: SESSION, topic: 'espresso', duration: 1200 }).success).toBe(false);
+    expect(ScriptSchema.safeParse({ sessionId: SESSION, topic: 'espresso', duration: 30 }).success).toBe(false);
 
-    const ok = ScriptSchema.safeParse({ topic: 'espresso', duration: 300 });
+    const ok = ScriptSchema.safeParse({ sessionId: SESSION, topic: 'espresso', duration: 300 });
     expect(ok.success).toBe(true);
   });
 
   it('defaults tone and duration so the form can omit them', () => {
-    const parsed = ScriptSchema.parse({ topic: 'why espresso tastes sour' });
+    const parsed = ScriptSchema.parse({ sessionId: SESSION, topic: 'why espresso tastes sour' });
     expect(parsed.tone).toBe('conversational');
     expect(parsed.duration).toBe(180);
   });
 
   it('rejects a tone the prompt does not handle', () => {
-    expect(ScriptSchema.safeParse({ topic: 'espresso', tone: 'sarcastic' }).success).toBe(false);
+    expect(ScriptSchema.safeParse({ sessionId: SESSION, topic: 'espresso', tone: 'sarcastic' }).success).toBe(false);
+  });
+});
+
+describe('free tools session and claim', () => {
+  it('requires a session id, since a run with no session can never be claimed', () => {
+    expect(IdeaSchema.safeParse({ niche: 'home espresso' }).success).toBe(false);
+    expect(ScriptSchema.safeParse({ topic: 'why espresso tastes sour' }).success).toBe(false);
+    expect(StorySchema.safeParse({ videoTopic: 'why espresso tastes sour' }).success).toBe(false);
+  });
+
+  it('rejects a session id that is not a uuid, so it cannot be a guessable string', () => {
+    expect(IdeaSchema.safeParse({ sessionId: 'me', niche: 'home espresso' }).success).toBe(false);
+  });
+
+  it('needs BOTH ids to claim: a run id alone travels in a URL', () => {
+    expect(ClaimSchema.safeParse({ runId: SESSION }).success).toBe(false);
+    expect(ClaimSchema.safeParse({ sessionId: SESSION }).success).toBe(false);
+    expect(ClaimSchema.safeParse({ runId: SESSION, sessionId: SESSION }).success).toBe(true);
+  });
+});
+
+describe('free story blueprint input', () => {
+  it('defaults every structural choice so the form can submit a topic alone', () => {
+    const parsed = StorySchema.parse({ sessionId: SESSION, videoTopic: 'why espresso tastes sour' });
+    expect(parsed.audienceLevel).toBe('general');
+    expect(parsed.videoDuration).toBe('medium');
+    expect(parsed.contentType).toBe('tutorial');
+    expect(parsed.storyMode).toBe('conversational');
+  });
+
+  it('rejects values outside the paid feature enums, so a claimed row stays valid', () => {
+    const base = { sessionId: SESSION, videoTopic: 'why espresso tastes sour' };
+    expect(StorySchema.safeParse({ ...base, videoDuration: 'epic' }).success).toBe(false);
+    expect(StorySchema.safeParse({ ...base, contentType: 'vlog' }).success).toBe(false);
+    expect(StorySchema.safeParse({ ...base, storyMode: 'chaotic' }).success).toBe(false);
   });
 });

--- a/apps/api/src/free-tools/free-tools.controller.ts
+++ b/apps/api/src/free-tools/free-tools.controller.ts
@@ -1,11 +1,21 @@
-import { Controller, Post, Body, Req, HttpException, HttpStatus } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiBody } from '@nestjs/swagger';
+import { Controller, Post, Body, Req, UseGuards, HttpException, HttpStatus } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBody, ApiBearerAuth } from '@nestjs/swagger';
 import { z } from 'zod';
 import type { Request } from 'express';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { allowRequest, getClientIp } from '../common/rate-limit';
-import { SCRIPT_TONES } from '@repo/validation';
+import {
+  SCRIPT_TONES,
+  AUDIENCE_LEVELS,
+  VIDEO_DURATIONS,
+  CONTENT_TYPES,
+  STORY_MODES,
+} from '@repo/validation';
+import { SupabaseAuthGuard } from '../guards/auth.guard';
+import type { AuthRequest } from '../common/interfaces/auth-request.interface';
+import { getUserId } from '../common/get-user-id';
 import { FreeToolsService } from './free-tools.service';
+import { FreeToolRunsService } from './free-tool-runs.service';
 
 /**
  * Anonymous generators behind the public /tools pages. No auth, no credits, no
@@ -31,13 +41,21 @@ function rateLimitOrThrow(req: Request) {
   }
 }
 
+/**
+ * Every free generation carries the visitor's localStorage session id, so the
+ * run can be stored now and handed to the account they create later.
+ */
+const sessionId = z.string().uuid('Invalid session');
+
 export const IdeaSchema = z.object({
+  sessionId,
   niche: z.string().trim().min(3, 'Tell us the topic or niche').max(200),
   audience: z.string().trim().max(200).optional().or(z.literal('')),
 });
 type IdeaInput = z.infer<typeof IdeaSchema>;
 
 export const ScriptSchema = z.object({
+  sessionId,
   topic: z.string().trim().min(3, 'Tell us what the video is about').max(500),
   tone: z.enum(SCRIPT_TONES).default('conversational'),
   // Capped well under the paid feature's range: the free sample proves quality,
@@ -48,21 +66,47 @@ export const ScriptSchema = z.object({
 });
 type ScriptInput = z.infer<typeof ScriptSchema>;
 
+/**
+ * The free story blueprint takes the six inputs that shape the structure and
+ * drops the four that only matter once there is a channel to personalize
+ * against (tone, additional context, an ideation link, the personalized flag).
+ */
+export const StorySchema = z.object({
+  sessionId,
+  videoTopic: z.string().trim().min(3, 'Tell us what the video is about').max(500),
+  targetAudience: z.string().trim().max(300).optional().or(z.literal('')),
+  audienceLevel: z.enum(AUDIENCE_LEVELS).default('general'),
+  videoDuration: z.enum(VIDEO_DURATIONS).default('medium'),
+  contentType: z.enum(CONTENT_TYPES).default('tutorial'),
+  storyMode: z.enum(STORY_MODES).default('conversational'),
+});
+type StoryInput = z.infer<typeof StorySchema>;
+
+export const ClaimSchema = z.object({
+  runId: z.string().uuid(),
+  sessionId,
+});
+type ClaimInput = z.infer<typeof ClaimSchema>;
+
 @ApiTags('free-tools')
 @Controller('free-tools')
 export class FreeToolsController {
-  constructor(private readonly freeToolsService: FreeToolsService) {}
+  constructor(
+    private readonly freeToolsService: FreeToolsService,
+    private readonly runs: FreeToolRunsService,
+  ) {}
 
   @Post('idea')
   @ApiOperation({
     summary: 'Generate one YouTube video idea (anonymous, free)',
-    description: 'Powers /tools/youtube-video-ideas-generator. Rate limited per IP.',
+    description: 'Powers /tools/free-youtube-video-ideas-generator. Rate limited per IP.',
   })
   @ApiBody({
     schema: {
       type: 'object',
-      required: ['niche'],
+      required: ['sessionId', 'niche'],
       properties: {
+        sessionId: { type: 'string', format: 'uuid' },
         niche: { type: 'string', example: 'home espresso for beginners' },
         audience: { type: 'string', example: 'people who just bought their first machine' },
       },
@@ -70,19 +114,23 @@ export class FreeToolsController {
   })
   async idea(@Body(new ZodValidationPipe(IdeaSchema)) body: IdeaInput, @Req() req: Request) {
     rateLimitOrThrow(req);
-    return this.freeToolsService.generateIdea(body.niche, body.audience || undefined);
+    const { sessionId: session, ...input } = body;
+    const result = await this.freeToolsService.generateIdea(body.niche, body.audience || undefined);
+    const runId = await this.runs.record(session, 'idea', input, result);
+    return { ...result, runId };
   }
 
   @Post('script')
   @ApiOperation({
     summary: 'Generate one YouTube script (anonymous, free)',
-    description: 'Powers /tools/youtube-script-generator. Rate limited per IP.',
+    description: 'Powers /tools/free-youtube-script-generator. Rate limited per IP.',
   })
   @ApiBody({
     schema: {
       type: 'object',
-      required: ['topic'],
+      required: ['sessionId', 'topic'],
       properties: {
+        sessionId: { type: 'string', format: 'uuid' },
         topic: { type: 'string', example: 'why your espresso tastes sour' },
         tone: { type: 'string', enum: [...SCRIPT_TONES], default: 'conversational' },
         duration: { type: 'integer', minimum: 60, maximum: 300, default: 180 },
@@ -93,9 +141,77 @@ export class FreeToolsController {
   })
   async script(@Body(new ZodValidationPipe(ScriptSchema)) body: ScriptInput, @Req() req: Request) {
     rateLimitOrThrow(req);
-    return this.freeToolsService.generateScript(body.topic, body.tone, body.duration, {
+    const { sessionId: session, ...input } = body;
+    const result = await this.freeToolsService.generateScript(body.topic, body.tone, body.duration, {
       storytelling: body.includeStorytelling,
       timestamps: body.includeTimestamps,
     });
+    const runId = await this.runs.record(session, 'script', input, result);
+    return { ...result, runId };
+  }
+
+  @Post('story')
+  @ApiOperation({
+    summary: 'Generate one story blueprint (anonymous, free)',
+    description: 'Powers /tools/free-youtube-story-structure-generator. Rate limited per IP.',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['sessionId', 'videoTopic'],
+      properties: {
+        sessionId: { type: 'string', format: 'uuid' },
+        videoTopic: { type: 'string', example: 'why your espresso tastes sour' },
+        targetAudience: { type: 'string', example: 'people who just bought their first machine' },
+        audienceLevel: { type: 'string', enum: [...AUDIENCE_LEVELS], default: 'general' },
+        videoDuration: { type: 'string', enum: [...VIDEO_DURATIONS], default: 'medium' },
+        contentType: { type: 'string', enum: [...CONTENT_TYPES], default: 'tutorial' },
+        storyMode: { type: 'string', enum: [...STORY_MODES], default: 'conversational' },
+      },
+    },
+  })
+  async story(@Body(new ZodValidationPipe(StorySchema)) body: StoryInput, @Req() req: Request) {
+    rateLimitOrThrow(req);
+    const { sessionId: session, ...input } = body;
+    const result = await this.freeToolsService.generateStory({
+      videoTopic: body.videoTopic,
+      targetAudience: body.targetAudience || undefined,
+      audienceLevel: body.audienceLevel,
+      videoDuration: body.videoDuration,
+      contentType: body.contentType,
+      storyMode: body.storyMode,
+    });
+    const runId = await this.runs.record(session, 'story', input, result);
+    return { ...result, runId };
+  }
+
+  /**
+   * Copy a stored anonymous run into the caller's account.
+   *
+   * SupabaseAuthGuard only, deliberately without OnboardedGuard: this runs
+   * seconds after signup, when the user has neither a trained AI nor a
+   * connected channel, and it spends no credits. The dashboard read routes it
+   * redirects to are gated the same way.
+   */
+  @Post('claim')
+  @UseGuards(SupabaseAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Claim an anonymous free-tool run into the signed-in account',
+    description:
+      'Materializes the stored run into scripts / ideation_jobs / story_builder_jobs and returns the dashboard path for it. Idempotent per run.',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['runId', 'sessionId'],
+      properties: {
+        runId: { type: 'string', format: 'uuid' },
+        sessionId: { type: 'string', format: 'uuid' },
+      },
+    },
+  })
+  async claim(@Body(new ZodValidationPipe(ClaimSchema)) body: ClaimInput, @Req() req: AuthRequest) {
+    return this.runs.claim(body.runId, body.sessionId, getUserId(req));
   }
 }

--- a/apps/api/src/free-tools/free-tools.module.ts
+++ b/apps/api/src/free-tools/free-tools.module.ts
@@ -1,11 +1,15 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { SupabaseModule } from '../supabase/supabase.module';
 import { FreeToolsController } from './free-tools.controller';
 import { FreeToolsService } from './free-tools.service';
+import { FreeToolRunsService } from './free-tool-runs.service';
 
 @Module({
-  imports: [ConfigModule],
+  // SupabaseModule for the run store: the generators themselves stay stateless,
+  // but a run has to survive the visitor navigating to /signup.
+  imports: [ConfigModule, SupabaseModule],
   controllers: [FreeToolsController],
-  providers: [FreeToolsService],
+  providers: [FreeToolsService, FreeToolRunsService],
 })
 export class FreeToolsModule {}

--- a/apps/api/src/free-tools/free-tools.service.ts
+++ b/apps/api/src/free-tools/free-tools.service.ts
@@ -1,5 +1,18 @@
 import { Injectable, Logger, InternalServerErrorException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import {
+  STORY_BLUEPRINT_RESPONSE_SCHEMA,
+  buildStoryBlueprintPrompt,
+  VIDEO_DURATION_LABELS,
+  CONTENT_TYPE_LABELS,
+  STORY_MODE_LABELS,
+  AUDIENCE_LEVEL_LABELS,
+  type VideoDuration,
+  type ContentType,
+  type StoryMode,
+  type AudienceLevel,
+  type StoryBuilderResult,
+} from '@repo/validation';
 import { createGoogleAI, GEMINI_TEXT_MODEL } from '../utils/genai';
 
 /**
@@ -141,5 +154,43 @@ ${options.timestamps ? '- Prefix each section heading with an estimated time mar
 - No emoji, no placeholder text, no "[insert X here]".`;
 
     return this.generateJson<FreeScript>(prompt, SCRIPT_SCHEMA, 'script');
+  }
+
+  /**
+   * The same blueprint the paid story builder produces, minus the creator style
+   * profile (there is no connected channel to read).
+   *
+   * It generates the FULL schema rather than a trimmed preview on purpose: the
+   * public page only renders the hook, the segments and the retention score, but
+   * the stored result has to drop into `story_builder_jobs.result` untouched when
+   * the visitor signs up and claims it. A trimmed sample would claim into a
+   * dashboard page with empty sections.
+   */
+  async generateStory(input: {
+    videoTopic: string;
+    targetAudience?: string;
+    audienceLevel: AudienceLevel;
+    videoDuration: VideoDuration;
+    contentType: ContentType;
+    storyMode: StoryMode;
+  }): Promise<StoryBuilderResult> {
+    const prompt = buildStoryBlueprintPrompt({
+      videoTopic: input.videoTopic,
+      durationLabel: VIDEO_DURATION_LABELS[input.videoDuration],
+      contentLabel: CONTENT_TYPE_LABELS[input.contentType],
+      storyModeLabel: STORY_MODE_LABELS[input.storyMode],
+      audienceLevel: AUDIENCE_LEVEL_LABELS[input.audienceLevel],
+      targetAudience: input.targetAudience,
+    });
+
+    const result = await this.generateJson<StoryBuilderResult>(
+      prompt,
+      STORY_BLUEPRINT_RESPONSE_SCHEMA,
+      'story blueprint',
+    );
+
+    // The worker stamps this after parsing too; the dashboard reads it off the
+    // result rather than the job row.
+    return { ...result, storyMode: input.storyMode };
   }
 }

--- a/apps/web/app/dashboard/research/new/page.tsx
+++ b/apps/web/app/dashboard/research/new/page.tsx
@@ -15,6 +15,7 @@ import { Sparkles, Loader2, ArrowLeft, Lock, Wand2, Compass, Bot, Lightbulb } fr
 import IdeationProgress from "@/components/dashboard/research/IdeationProgress";
 import { useIdeation } from "@/hooks/useIdeation";
 import { useAISetupGate } from "@/hooks/useAISetupGate";
+import { useClaimFreeRun } from "@/hooks/useClaimFreeRun";
 import { useCurrentPlan } from "@/hooks/useCurrentPlan";
 import Link from "next/link";
 
@@ -30,6 +31,9 @@ export default function NewIdeationPage() {
   // Every plan has the same idea capabilities, usage is bounded only by credits.
   const { maxIdeas, loading: planLoading } = useCurrentPlan();
   const gate = useAISetupGate();
+  // A `?freeRun=` from the signup flow: the visitor made this at /tools
+  // before they had an account. Claim it, then redirect to the real record.
+  const { claiming } = useClaimFreeRun("idea");
   const [customCount, setCustomCount] = useState("3");
   const {
     context, setContext,
@@ -80,7 +84,7 @@ export default function NewIdeationPage() {
 
   let content: React.ReactNode;
 
-  if (isLoadingProfile || planLoading) {
+  if (isLoadingProfile || planLoading || claiming) {
     content = (
       <motion.div
         className="max-w-xl mx-auto space-y-4"

--- a/apps/web/app/dashboard/scripts/new/page.tsx
+++ b/apps/web/app/dashboard/scripts/new/page.tsx
@@ -10,6 +10,7 @@ import ScriptGenerationForm from "@/components/dashboard/scripts/ScriptGeneratio
 import ScriptOutputPanel from "@/components/dashboard/scripts/ScriptOutputPanel";
 import { ScriptHowItWorksGuide } from "@/components/dashboard/scripts/ScriptHowItWorksGuide";
 import { useAISetupGate } from "@/hooks/useAISetupGate";
+import { useClaimFreeRun } from "@/hooks/useClaimFreeRun";
 import { Skeleton } from "@repo/ui/skeleton";
 import { Badge } from "@repo/ui/badge";
 import { Sparkles } from "lucide-react";
@@ -21,6 +22,9 @@ function NewScriptPageInner() {
   const searchParams = useSearchParams()
   const { profileLoading } = useSupabase()
   const gate = useAISetupGate()
+  // A `?freeRun=` from the signup flow: the visitor made this at /tools
+  // before they had an account. Claim it, then redirect to the real record.
+  const { claiming } = useClaimFreeRun("script")
 
   const ideationId = searchParams.get("ideationId") ?? undefined
   const ideaIndex = searchParams.get("ideaIndex") != null ? Number(searchParams.get("ideaIndex")) : undefined
@@ -48,7 +52,7 @@ function NewScriptPageInner() {
     if (ideaTitle && !hook.prompt) hook.setPrompt(ideaTitle)
   }, [ideaTitle])
 
-  if (profileLoading) {
+  if (profileLoading || claiming) {
     return (
       <div className="container py-8 space-y-4">
         <Skeleton className="h-10 w-64" />

--- a/apps/web/app/dashboard/story-builder/new/page.tsx
+++ b/apps/web/app/dashboard/story-builder/new/page.tsx
@@ -10,6 +10,7 @@ import { StoryBuilderForm } from "@/components/dashboard/story-builder/StoryBuil
 import { StoryBuilderProgress } from "@/components/dashboard/story-builder/StoryBuilderProgress";
 import { StoryBuilderResults } from "@/components/dashboard/story-builder/StoryBuilderResults";
 import { useAISetupGate } from "@/hooks/useAISetupGate";
+import { useClaimFreeRun } from "@/hooks/useClaimFreeRun";
 import { Skeleton } from "@repo/ui/skeleton";
 import { Badge } from "@repo/ui/badge";
 import { Sparkles } from "lucide-react"
@@ -19,6 +20,9 @@ export default function NewStoryBuilderPage() {
   const searchParams = useSearchParams()
   const { profileLoading } = useSupabase()
   const gate = useAISetupGate()
+  // A `?freeRun=` from the signup flow: the visitor made this at /tools
+  // before they had an account. Claim it, then redirect to the real record.
+  const { claiming } = useClaimFreeRun("story")
 
   const hook = useStoryBuilder({
     onComplete: (id) => router.push(`/dashboard/story-builder/${id}`),
@@ -34,7 +38,7 @@ export default function NewStoryBuilderPage() {
     }
   }, [searchParams])
 
-  if (profileLoading) {
+  if (profileLoading || claiming) {
     return (
       <div className="container py-8 space-y-4">
         <Skeleton className="h-10 w-64" />

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -121,11 +121,6 @@ export default function RootLayout({
             gtag('config', 'G-RVSYKESCPC');
           `}
         </Script>
-        <Script
-          src="https://analytics.ahrefs.com/analytics.js"
-          data-key={process.env.NEXT_PUBLIC_AHREFS_KEY}
-          strategy="afterInteractive"
-        />
       </body>
     </html>
   )

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -121,6 +121,11 @@ export default function RootLayout({
             gtag('config', 'G-RVSYKESCPC');
           `}
         </Script>
+        <Script
+          src="https://analytics.ahrefs.com/analytics.js"
+          data-key={process.env.NEXT_PUBLIC_AHREFS_KEY}
+          strategy="afterInteractive"
+        />
       </body>
     </html>
   )

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -71,11 +71,21 @@ function SignupForm() {
     }
   };
 
+  /**
+   * Where to land after signing up. Set by the free-tool pages so a result
+   * generated at /tools survives the signup and is claimed into the new
+   * account (see lib/free-tool-session.ts). Same-origin paths only, and the
+   * auth callback narrows it again to /dashboard before honoring it.
+   */
+  const rawNext = searchParams.get("next");
+  const nextPath =
+    rawNext?.startsWith("/") && !rawNext.startsWith("//") ? rawNext : null;
+
   useEffect(() => {
     if (user) {
-      router.push("/dashboard");
+      router.push(nextPath ?? "/dashboard");
     }
-  }, [user, router]);
+  }, [user, router, nextPath]);
 
   // Check the code before promising anyone a bonus for it. Doing this at sign-up
   // time instead of after account creation is what keeps a mistyped or expired
@@ -168,7 +178,7 @@ function SignupForm() {
         email: details.email!,
         password: details.password!,
         options: {
-          emailRedirectTo: `${window.location.origin}/api/auth/callback?next=/login`,
+          emailRedirectTo: `${window.location.origin}/api/auth/callback?next=${encodeURIComponent(nextPath ?? "/login")}`,
           data: {
             full_name: details.name,
           },
@@ -180,7 +190,12 @@ function SignupForm() {
       if (data.user) {
         toast.success("Account created!", { description: "Please check your email to verify your account." });
         await trackReferral(data.user.email);
-        router.push("/login");
+        // Carry `next` to the login page too: the confirmation email already
+        // has it, but someone who signs in by hand from here should land in the
+        // same place.
+        router.push(
+          nextPath ? `/login?redirectTo=${encodeURIComponent(nextPath)}` : "/login",
+        );
       }
     } catch (error: unknown) {
       if (isZodError(error)) {
@@ -208,9 +223,10 @@ function SignupForm() {
     }
     setLoading(true);
     try {
-      const redirectUrl = referralCode
-        ? `${window.location.origin}/api/auth/callback?ref=${referralCode}`
-        : `${window.location.origin}/api/auth/callback`;
+      const callbackUrl = new URL("/api/auth/callback", window.location.origin);
+      if (referralCode) callbackUrl.searchParams.set("ref", referralCode);
+      if (nextPath) callbackUrl.searchParams.set("next", nextPath);
+      const redirectUrl = callbackUrl.toString();
 
       const { error } = await supabase.auth.signInWithOAuth({
         provider: "google",

--- a/apps/web/app/tools/free-youtube-script-generator/layout.tsx
+++ b/apps/web/app/tools/free-youtube-script-generator/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next"
+import { getFreeTool } from "@/lib/free-tools"
+import { ToolJsonLd, toolMetadata } from "@/lib/tool-seo"
+
+const tool = getFreeTool("free-youtube-script-generator")!
+
+export const metadata: Metadata = toolMetadata(tool)
+
+export default function ScriptGeneratorLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <ToolJsonLd tool={tool} />
+      {children}
+    </>
+  )
+}

--- a/apps/web/app/tools/free-youtube-script-generator/page.tsx
+++ b/apps/web/app/tools/free-youtube-script-generator/page.tsx
@@ -2,7 +2,7 @@ import ToolPageShell from "@/components/tools/ToolPageShell"
 import ScriptGeneratorWidget from "@/components/tools/ScriptGeneratorWidget"
 import { getFreeTool } from "@/lib/free-tools"
 
-const tool = getFreeTool("youtube-script-generator")!
+const tool = getFreeTool("free-youtube-script-generator")!
 
 export default function YouTubeScriptGeneratorPage() {
   return (

--- a/apps/web/app/tools/free-youtube-story-structure-generator/layout.tsx
+++ b/apps/web/app/tools/free-youtube-story-structure-generator/layout.tsx
@@ -2,11 +2,15 @@ import type { Metadata } from "next"
 import { getFreeTool } from "@/lib/free-tools"
 import { ToolJsonLd, toolMetadata } from "@/lib/tool-seo"
 
-const tool = getFreeTool("youtube-script-generator")!
+const tool = getFreeTool("free-youtube-story-structure-generator")!
 
 export const metadata: Metadata = toolMetadata(tool)
 
-export default function ScriptGeneratorLayout({ children }: { children: React.ReactNode }) {
+export default function StoryStructureGeneratorLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
   return (
     <>
       <ToolJsonLd tool={tool} />

--- a/apps/web/app/tools/free-youtube-story-structure-generator/page.tsx
+++ b/apps/web/app/tools/free-youtube-story-structure-generator/page.tsx
@@ -1,0 +1,13 @@
+import ToolPageShell from "@/components/tools/ToolPageShell"
+import StoryStructureWidget from "@/components/tools/StoryStructureWidget"
+import { getFreeTool } from "@/lib/free-tools"
+
+const tool = getFreeTool("free-youtube-story-structure-generator")!
+
+export default function YouTubeStoryStructureGeneratorPage() {
+  return (
+    <ToolPageShell tool={tool}>
+      <StoryStructureWidget />
+    </ToolPageShell>
+  )
+}

--- a/apps/web/app/tools/free-youtube-video-ideas-generator/layout.tsx
+++ b/apps/web/app/tools/free-youtube-video-ideas-generator/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next"
 import { getFreeTool } from "@/lib/free-tools"
 import { ToolJsonLd, toolMetadata } from "@/lib/tool-seo"
 
-const tool = getFreeTool("youtube-video-ideas-generator")!
+const tool = getFreeTool("free-youtube-video-ideas-generator")!
 
 export const metadata: Metadata = toolMetadata(tool)
 

--- a/apps/web/app/tools/free-youtube-video-ideas-generator/page.tsx
+++ b/apps/web/app/tools/free-youtube-video-ideas-generator/page.tsx
@@ -2,7 +2,7 @@ import ToolPageShell from "@/components/tools/ToolPageShell"
 import IdeaGeneratorWidget from "@/components/tools/IdeaGeneratorWidget"
 import { getFreeTool } from "@/lib/free-tools"
 
-const tool = getFreeTool("youtube-video-ideas-generator")!
+const tool = getFreeTool("free-youtube-video-ideas-generator")!
 
 export default function YouTubeVideoIdeasGeneratorPage() {
   return (

--- a/apps/web/app/tools/page.tsx
+++ b/apps/web/app/tools/page.tsx
@@ -1,13 +1,28 @@
+import type { ComponentType } from "react"
 import Link from "next/link"
-import { ArrowRight, Sparkles, Zap, Lock, Wand2 } from "lucide-react"
+import { ArrowRight, Clapperboard, Sparkles, Zap, Lock, Wand2 } from "lucide-react"
 import LandingPageNavbar from "@/components/landingPage/LandingPageNavbar"
 import Footer from "@/components/footer"
 import SmoothScroll from "@/components/SmoothScroll"
 import FeatureCard from "@/components/feature-card"
 import GoogleSignupCta from "@/components/tools/GoogleSignupCta"
 import ConnectChannelCta from "@/components/tools/ConnectChannelCta"
+import SearchIcon from "@/components/dashboard/sidebar/icons/SearchIcon"
+import FileTextIcon from "@/components/dashboard/sidebar/icons/FileTextIcon"
 import { FREE_TOOLS } from "@/lib/free-tools"
 import { CORE_FEATURES, EXTRA_FEATURES } from "@/lib/product-features"
+
+/**
+ * Each tool wears the icon its paid feature wears in the dashboard sidebar, so
+ * the free sample and the real thing read as the same product. Kept here rather
+ * than in lib/free-tools.ts because this is the only place one renders, and the
+ * registry has to stay importable from a plain node script.
+ */
+const TOOL_ICON: Record<string, ComponentType<{ className: string }>> = {
+  "free-youtube-video-ideas-generator": SearchIcon,
+  "free-youtube-script-generator": FileTextIcon,
+  "free-youtube-story-structure-generator": Clapperboard,
+}
 
 /**
  * The /tools hub. The tools themselves are the first thing under the hero,
@@ -71,14 +86,16 @@ export default function ToolsPage() {
 
           {/* The tools, immediately */}
           <div className="relative z-10 mx-auto mt-12 grid max-w-5xl gap-6 px-6 md:grid-cols-2">
-            {FREE_TOOLS.map((tool) => (
+            {FREE_TOOLS.map((tool) => {
+              const Icon = TOOL_ICON[tool.slug] ?? Sparkles
+              return (
               <Link
                 key={tool.slug}
                 href={`/tools/${tool.slug}`}
                 className="group flex flex-col rounded-2xl border border-slate-200 bg-white p-7 shadow-sm transition hover:border-purple-300 hover:shadow-lg"
               >
                 <span className="flex h-12 w-12 items-center justify-center rounded-xl border border-slate-100 bg-purple-50 text-purple-600 shadow-sm">
-                  <tool.icon className="h-6 w-6" />
+                  <Icon className="h-6 w-6" />
                 </span>
                 <h2 className="mt-4 text-lg font-semibold text-slate-900 group-hover:text-purple-700">
                   {tool.name}
@@ -94,7 +111,8 @@ export default function ToolsPage() {
                   />
                 </span>
               </Link>
-            ))}
+              )
+            })}
           </div>
         </section>
 

--- a/apps/web/components/tools/IdeaGeneratorWidget.tsx
+++ b/apps/web/components/tools/IdeaGeneratorWidget.tsx
@@ -23,7 +23,7 @@ interface FreeIdea {
   opportunityScore: number
 }
 
-const SLUG = "youtube-video-ideas-generator"
+const SLUG = "free-youtube-video-ideas-generator"
 
 // CSS rather than motion, deliberately. A motion `initial={{ opacity: 0 }}`
 // leaves the element invisible until the LazyMotion feature bundle has loaded
@@ -42,8 +42,17 @@ function scoreTone(score: number) {
 export default function IdeaGeneratorWidget() {
   const [niche, setNiche] = useState("")
   const [audience, setAudience] = useState("")
-  const { result, isLoading, error, showSignupGate, closeSignupGate, run } =
-    useFreeTool<FreeIdea>(SLUG, "/api/v1/free-tools/idea")
+  const {
+    result,
+    runId,
+    isLoading,
+    error,
+    showSignupGate,
+    gateReason,
+    requestExport,
+    closeSignupGate,
+    run,
+  } = useFreeTool<FreeIdea>(SLUG, "/api/v1/free-tools/idea")
 
   const canSubmit = niche.trim().length >= 3 && !isLoading
 
@@ -219,8 +228,11 @@ export default function IdeaGeneratorWidget() {
           <ToolResultActions
             copyText={asPlainText(result)}
             toolSlug={SLUG}
+            tool="idea"
+            runId={runId}
+            onExport={requestExport}
             nextStep={{
-              href: "/tools/youtube-script-generator",
+              href: "/tools/free-youtube-script-generator",
               label: "Turn this into a full script →",
             }}
           />
@@ -232,6 +244,9 @@ export default function IdeaGeneratorWidget() {
         onOpenChange={(next) => !next && closeSignupGate()}
         toolSlug={SLUG}
         toolName="video ideas generator"
+        tool="idea"
+        runId={runId}
+        reason={gateReason}
       />
 
       {result && (

--- a/apps/web/components/tools/ScriptGeneratorWidget.tsx
+++ b/apps/web/components/tools/ScriptGeneratorWidget.tsx
@@ -24,7 +24,7 @@ interface FreeScript {
   script: string
 }
 
-const SLUG = "youtube-script-generator"
+const SLUG = "free-youtube-script-generator"
 
 // CSS rather than motion, deliberately. A motion `initial={{ opacity: 0 }}`
 // leaves the element invisible until the LazyMotion feature bundle has loaded
@@ -120,8 +120,17 @@ export default function ScriptGeneratorWidget() {
   const [duration, setDuration] = useState<string>("180")
   const [includeStorytelling, setIncludeStorytelling] = useState(false)
   const [includeTimestamps, setIncludeTimestamps] = useState(false)
-  const { result, isLoading, error, showSignupGate, closeSignupGate, run } =
-    useFreeTool<FreeScript>(SLUG, "/api/v1/free-tools/script")
+  const {
+    result,
+    runId,
+    isLoading,
+    error,
+    showSignupGate,
+    gateReason,
+    requestExport,
+    closeSignupGate,
+    run,
+  } = useFreeTool<FreeScript>(SLUG, "/api/v1/free-tools/script")
 
   const canSubmit = topic.trim().length >= 3 && !isLoading
 
@@ -277,8 +286,11 @@ export default function ScriptGeneratorWidget() {
           <ToolResultActions
             copyText={`${result.title}\n\n${result.script}`}
             toolSlug={SLUG}
+            tool="script"
+            runId={runId}
+            onExport={requestExport}
             nextStep={{
-              href: "/tools/youtube-video-ideas-generator",
+              href: "/tools/free-youtube-video-ideas-generator",
               label: "Need the next video idea? →",
             }}
           />
@@ -290,6 +302,9 @@ export default function ScriptGeneratorWidget() {
         onOpenChange={(next) => !next && closeSignupGate()}
         toolSlug={SLUG}
         toolName="script generator"
+        tool="script"
+        runId={runId}
+        reason={gateReason}
       />
 
       {result && (

--- a/apps/web/components/tools/SignupGateModal.tsx
+++ b/apps/web/components/tools/SignupGateModal.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { Check, Sparkles } from "lucide-react"
+import { Check, Download, Sparkles } from "lucide-react"
 import {
   Dialog,
   DialogContent,
@@ -11,40 +11,70 @@ import {
 } from "@repo/ui/dialog"
 import { Button } from "@repo/ui/button"
 import { FREE_TOOL_SIGNUP_BENEFITS } from "@/lib/free-tools"
+import { loginHrefForRun, signupHrefForRun, type FreeToolKind } from "@/lib/free-tool-session"
 
 /**
- * Shown on the second generation attempt on any /tools page.
+ * The one signup ask on a /tools page, in two moods.
  *
- * Deliberately dismissible and not a hard paywall: the visitor already got
- * something that worked, so the ask is "keep going", not "pay up". `ref` on the
- * signup link carries which tool converted them.
+ * "limit"  — shown on the second generation attempt. The visitor already got
+ *            something that worked, so the ask is "keep going", not "pay up".
+ * "export" — shown when they click Export. Harder ask, better moment: they are
+ *            asking to take the result with them, which is the point at which
+ *            an account is genuinely the answer rather than a toll.
+ *
+ * Both carry `runId` so signing up hands the result back instead of losing it.
+ * Dismissible in both moods: the result stays on screen either way.
  */
 export default function SignupGateModal({
   open,
   onOpenChange,
   toolSlug,
   toolName,
+  tool,
+  runId = null,
+  reason = "limit",
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   toolSlug: string
   toolName: string
+  /** Which real feature a claimed run materializes into. */
+  tool: FreeToolKind
+  runId?: string | null
+  reason?: "limit" | "export"
 }) {
-  const signupHref = `/signup?ref=tool-${toolSlug}`
+  const signupHref = signupHrefForRun(tool, toolSlug, runId)
+  const isExport = reason === "export"
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md bg-white">
         <DialogHeader>
           <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-purple-500 to-indigo-500">
-            <Sparkles className="h-6 w-6 text-white" aria-hidden="true" />
+            {isExport ? (
+              <Download className="h-6 w-6 text-white" aria-hidden="true" />
+            ) : (
+              <Sparkles className="h-6 w-6 text-white" aria-hidden="true" />
+            )}
           </div>
           <DialogTitle className="text-center text-xl font-bold text-slate-900">
-            That was your free one. Want 500 more?
+            {isExport
+              ? "Create a free account to export"
+              : "That was your free one. Want 500 more?"}
           </DialogTitle>
           <DialogDescription className="text-center text-slate-600">
-            Create a free Creator AI account to keep using the {toolName} and everything else.
-            No credit card.
+            {isExport ? (
+              <>
+                Exporting needs an account, and it is free. Sign up and this{" "}
+                {toolName} result is waiting in your dashboard, ready to edit,
+                export and build on. Nothing is lost.
+              </>
+            ) : (
+              <>
+                Create a free Creator AI account to keep using the {toolName} and
+                everything else. No credit card.
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
 
@@ -62,12 +92,12 @@ export default function SignupGateModal({
             asChild
             className="w-full bg-gradient-to-r from-purple-500 via-indigo-500 to-cyan-500 text-white hover:brightness-110"
           >
-            <Link href={signupHref}>Get 500 free credits</Link>
+            <Link href={signupHref}>
+              {isExport ? "Sign up and export" : "Get 500 free credits"}
+            </Link>
           </Button>
           <Button asChild variant="ghost" className="w-full text-slate-600">
-            <Link href={`/login?redirectTo=${encodeURIComponent("/dashboard")}`}>
-              I already have an account
-            </Link>
+            <Link href={loginHrefForRun(tool, runId)}>I already have an account</Link>
           </Button>
         </div>
 

--- a/apps/web/components/tools/StoryStructureWidget.tsx
+++ b/apps/web/components/tools/StoryStructureWidget.tsx
@@ -1,0 +1,409 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { Loader2, Sparkles, Clapperboard, Gauge, Anchor, Layers, Flag } from "lucide-react"
+import { Button } from "@repo/ui/button"
+import { Input } from "@repo/ui/input"
+import { Label } from "@repo/ui/label"
+import { Textarea } from "@repo/ui/textarea"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/select"
+import {
+  AUDIENCE_LEVELS,
+  AUDIENCE_LEVEL_LABELS,
+  CONTENT_TYPES,
+  CONTENT_TYPE_LABELS,
+  STORY_MODES,
+  STORY_MODE_LABELS,
+  VIDEO_DURATIONS,
+  VIDEO_DURATION_LABELS,
+  type StoryBuilderResult,
+} from "@repo/validation"
+import { useFreeTool } from "@/hooks/useFreeTool"
+import SignupGateModal from "./SignupGateModal"
+import ToolResultActions from "./ToolResultActions"
+import { TOOL_FIELD, TOOL_FIELD_TEXTAREA } from "./field-styles"
+
+const SLUG = "free-youtube-story-structure-generator"
+
+// CSS rather than motion, deliberately. A motion `initial={{ opacity: 0 }}`
+// leaves the element invisible until the LazyMotion feature bundle has loaded
+// and run, and if that never happens the generated blueprint never appears at
+// all. Same reasoning as the script and idea widgets.
+const RISE = "animate-in fade-in slide-in-from-bottom-4 fill-mode-both duration-500"
+
+/** Green above 7, amber above 5, red below. An honest score has to look honest. */
+function scoreTone(score: number) {
+  if (score >= 7) return "bg-emerald-50 text-emerald-700 border-emerald-200"
+  if (score >= 5) return "bg-amber-50 text-amber-700 border-amber-200"
+  return "bg-rose-50 text-rose-700 border-rose-200"
+}
+
+const RISK_TONE: Record<string, string> = {
+  low: "text-emerald-700",
+  medium: "text-amber-700",
+  high: "text-rose-700",
+}
+
+/**
+ * The plain-text form of a blueprint, for the Copy button.
+ *
+ * Only the sections the page renders. The stored run keeps everything, and the
+ * rest appears in the dashboard once the run is claimed.
+ */
+function asPlainText(r: StoryBuilderResult): string {
+  const b = r.structuredBlueprint
+  return [
+    "HOOK (0-15s)",
+    b.hook.openingLine,
+    `Curiosity: ${b.hook.curiosityStatement}`,
+    `Promise: ${b.hook.promise}`,
+    `Stakes: ${b.hook.stakes}`,
+    `On screen: ${b.hook.visualSuggestion}`,
+    "",
+    "CONTEXT (15-45s)",
+    `Problem: ${b.contextSetup.problem}`,
+    `Why it matters: ${b.contextSetup.whyItMatters}`,
+    "",
+    "ESCALATION",
+    ...b.escalationSegments.map((s) =>
+      [
+        `${s.segmentNumber}. ${s.title} (${s.estimatedDuration})`,
+        `   Micro-hook: ${s.microHook}`,
+        `   Insight: ${s.insight}`,
+        `   Into the next: ${s.transitionTension}`,
+      ].join("\n"),
+    ),
+    "",
+    "CLIMAX",
+    `Biggest insight: ${b.climax.biggestInsight}`,
+    `Twist: ${b.climax.unexpectedTwist}`,
+    "",
+    "RESOLUTION",
+    `Close the loop: ${b.resolution.closeLoop}`,
+    `Soft CTA: ${b.resolution.softCTA}`,
+    "",
+    `Retention score: ${r.tensionMapping.retentionScore}/10 (drop risk: ${r.tensionMapping.predictedDropRisk})`,
+  ].join("\n")
+}
+
+export default function StoryStructureWidget() {
+  const [videoTopic, setVideoTopic] = useState("")
+  const [targetAudience, setTargetAudience] = useState("")
+  const [audienceLevel, setAudienceLevel] = useState<string>("general")
+  const [videoDuration, setVideoDuration] = useState<string>("medium")
+  const [contentType, setContentType] = useState<string>("tutorial")
+  const [storyMode, setStoryMode] = useState<string>("conversational")
+
+  const {
+    result,
+    runId,
+    isLoading,
+    error,
+    showSignupGate,
+    gateReason,
+    requestExport,
+    closeSignupGate,
+    run,
+  } = useFreeTool<StoryBuilderResult>(SLUG, "/api/v1/free-tools/story")
+
+  const canSubmit = videoTopic.trim().length >= 3 && !isLoading
+
+  return (
+    <div className="w-full">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          if (canSubmit)
+            run({
+              videoTopic: videoTopic.trim(),
+              targetAudience: targetAudience.trim(),
+              audienceLevel,
+              videoDuration,
+              contentType,
+              storyMode,
+            })
+        }}
+        className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6"
+      >
+        <div className="space-y-1.5">
+          <Label htmlFor="video-topic" className="text-sm font-medium text-slate-700">
+            What is the video about? <span className="text-rose-500">*</span>
+          </Label>
+          <Textarea
+            id="video-topic"
+            value={videoTopic}
+            onChange={(e) => setVideoTopic(e.target.value)}
+            placeholder="Why your espresso tastes sour, and the three things to change first"
+            maxLength={500}
+            rows={3}
+            required
+            className={TOOL_FIELD_TEXTAREA}
+          />
+          <p className="text-xs text-slate-500">
+            A promise structures better than a topic. {videoTopic.length}/500
+          </p>
+        </div>
+
+        <div className="mt-4 space-y-1.5">
+          <Label htmlFor="target-audience" className="text-sm font-medium text-slate-700">
+            Who is it for? <span className="text-slate-400">(optional)</span>
+          </Label>
+          <Input
+            id="target-audience"
+            value={targetAudience}
+            onChange={(e) => setTargetAudience(e.target.value)}
+            placeholder="People who just bought their first machine"
+            maxLength={300}
+            className={TOOL_FIELD}
+          />
+        </div>
+
+        <div className="mt-4 grid gap-4 sm:grid-cols-2">
+          {[
+            {
+              id: "video-duration",
+              label: "Length",
+              value: videoDuration,
+              onChange: setVideoDuration,
+              options: VIDEO_DURATIONS.map((v) => ({ value: v, label: VIDEO_DURATION_LABELS[v] })),
+            },
+            {
+              id: "content-type",
+              label: "Structure template",
+              value: contentType,
+              onChange: setContentType,
+              options: CONTENT_TYPES.map((v) => ({ value: v, label: CONTENT_TYPE_LABELS[v] })),
+            },
+            {
+              id: "story-mode",
+              label: "Story mode",
+              value: storyMode,
+              onChange: setStoryMode,
+              options: STORY_MODES.map((v) => ({ value: v, label: STORY_MODE_LABELS[v] })),
+            },
+            {
+              id: "audience-level",
+              label: "Audience level",
+              value: audienceLevel,
+              onChange: setAudienceLevel,
+              options: AUDIENCE_LEVELS.map((v) => ({ value: v, label: AUDIENCE_LEVEL_LABELS[v] })),
+            },
+          ].map((field) => (
+            <div key={field.id} className="space-y-1.5">
+              <Label htmlFor={field.id} className="text-sm font-medium text-slate-700">
+                {field.label}
+              </Label>
+              <Select value={field.value} onValueChange={field.onChange}>
+                <SelectTrigger id={field.id} className={TOOL_FIELD}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {field.options.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ))}
+        </div>
+
+        <Button
+          type="submit"
+          disabled={!canSubmit}
+          className="mt-5 h-12 w-full bg-gradient-to-r from-purple-500 via-indigo-500 to-cyan-500 text-base font-medium text-white transition hover:brightness-110"
+        >
+          {isLoading ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+              Structuring your video…
+            </>
+          ) : (
+            <>
+              <Sparkles className="mr-2 h-4 w-4" aria-hidden="true" />
+              Build my story structure
+            </>
+          )}
+        </Button>
+
+        <p className="mt-3 text-xs text-slate-500">
+          Free · no account needed for your first blueprint · takes about 30 seconds
+        </p>
+
+        {error && (
+          <p role="alert" className="mt-3 rounded-lg bg-rose-50 px-3 py-2 text-sm text-rose-700">
+            {error}
+          </p>
+        )}
+      </form>
+
+      {result && (
+        <div className={`${RISE} mt-6 rounded-2xl border border-purple-200 bg-white p-5 shadow-sm sm:p-6`}>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-purple-600">
+              <Clapperboard className="h-4 w-4" aria-hidden="true" />
+              Your story blueprint
+            </div>
+            <span
+              className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${scoreTone(
+                result.tensionMapping.retentionScore,
+              )}`}
+            >
+              <Gauge className="mr-1 inline h-3 w-3" aria-hidden="true" />
+              Retention {result.tensionMapping.retentionScore}/10
+            </span>
+          </div>
+
+          <section className={`${RISE} delay-150 mt-5`}>
+            <h3 className="flex items-center gap-1.5 text-sm font-semibold text-slate-900">
+              <Anchor className="h-4 w-4 text-purple-600" aria-hidden="true" />
+              Hook · first 15 seconds
+            </h3>
+            <p className="mt-2 rounded-lg bg-slate-50 p-3 text-[0.95rem] font-medium leading-relaxed text-slate-800">
+              {result.structuredBlueprint.hook.openingLine}
+            </p>
+            <dl className="mt-3 grid gap-3 sm:grid-cols-2">
+              {[
+                ["Promise", result.structuredBlueprint.hook.promise],
+                ["Stakes", result.structuredBlueprint.hook.stakes],
+                ["Curiosity", result.structuredBlueprint.hook.curiosityStatement],
+                ["On screen", result.structuredBlueprint.hook.visualSuggestion],
+              ].map(([term, value]) => (
+                <div key={term}>
+                  <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    {term}
+                  </dt>
+                  <dd className="mt-1 text-sm leading-relaxed text-slate-600">{value}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          <section className={`${RISE} delay-300 mt-6`}>
+            <h3 className="text-sm font-semibold text-slate-900">Context · 15 to 45 seconds</h3>
+            <p className="mt-2 text-sm leading-relaxed text-slate-600">
+              {result.structuredBlueprint.contextSetup.problem}
+            </p>
+            <p className="mt-1.5 text-sm leading-relaxed text-slate-600">
+              {result.structuredBlueprint.contextSetup.whyItMatters}
+            </p>
+          </section>
+
+          <section className={`${RISE} delay-300 mt-6`}>
+            <h3 className="flex items-center gap-1.5 text-sm font-semibold text-slate-900">
+              <Layers className="h-4 w-4 text-purple-600" aria-hidden="true" />
+              Escalation segments
+            </h3>
+            <ol className="mt-3 space-y-3">
+              {result.structuredBlueprint.escalationSegments.map((segment) => (
+                <li
+                  key={segment.segmentNumber}
+                  className="rounded-xl border border-slate-200 p-4"
+                >
+                  <div className="flex flex-wrap items-baseline justify-between gap-2">
+                    <h4 className="font-semibold text-slate-900">
+                      {segment.segmentNumber}. {segment.title}
+                    </h4>
+                    <span className="text-xs text-slate-500">{segment.estimatedDuration}</span>
+                  </div>
+                  <p className="mt-2 text-sm leading-relaxed text-slate-600">
+                    <span className="font-medium text-slate-800">Micro-hook: </span>
+                    {segment.microHook}
+                  </p>
+                  <p className="mt-1.5 text-sm leading-relaxed text-slate-600">{segment.insight}</p>
+                  <p className="mt-1.5 text-sm leading-relaxed text-slate-500">
+                    <span className="font-medium">Into the next: </span>
+                    {segment.transitionTension}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <section className={`${RISE} delay-500 mt-6 grid gap-4 sm:grid-cols-2`}>
+            <div>
+              <h3 className="text-sm font-semibold text-slate-900">Climax</h3>
+              <p className="mt-2 text-sm leading-relaxed text-slate-600">
+                {result.structuredBlueprint.climax.biggestInsight}
+              </p>
+              <p className="mt-1.5 text-sm leading-relaxed text-slate-500">
+                <span className="font-medium">Twist: </span>
+                {result.structuredBlueprint.climax.unexpectedTwist}
+              </p>
+            </div>
+            <div>
+              <h3 className="flex items-center gap-1.5 text-sm font-semibold text-slate-900">
+                <Flag className="h-4 w-4 text-purple-600" aria-hidden="true" />
+                Resolution
+              </h3>
+              <p className="mt-2 text-sm leading-relaxed text-slate-600">
+                {result.structuredBlueprint.resolution.closeLoop}
+              </p>
+              <p className="mt-1.5 text-sm leading-relaxed text-slate-500">
+                <span className="font-medium">Soft CTA: </span>
+                {result.structuredBlueprint.resolution.softCTA}
+              </p>
+            </div>
+          </section>
+
+          <p className="mt-6 rounded-xl border border-purple-100 bg-purple-50/60 p-4 text-sm leading-relaxed text-slate-700">
+            <span className="font-semibold text-slate-900">
+              Drop risk:{" "}
+              <span className={RISK_TONE[result.tensionMapping.predictedDropRisk] ?? "text-slate-700"}>
+                {result.tensionMapping.predictedDropRisk}
+              </span>
+              .
+            </span>{" "}
+            This blueprint also carries {result.tensionMapping.curiosityLoops} curiosity loops,{" "}
+            {result.retentionBeats?.length ?? 0} retention beats, pattern interrupts, the emotional
+            arc, CTA placements and a full production outline. Export it to see all of it in your
+            dashboard.
+          </p>
+
+          <ToolResultActions
+            copyText={asPlainText(result)}
+            toolSlug={SLUG}
+            tool="story"
+            runId={runId}
+            onExport={requestExport}
+            nextStep={{
+              href: "/tools/free-youtube-script-generator",
+              label: "Turn this into a full script →",
+            }}
+          />
+        </div>
+      )}
+
+      <SignupGateModal
+        open={showSignupGate}
+        onOpenChange={(next) => !next && closeSignupGate()}
+        toolSlug={SLUG}
+        toolName="story structure generator"
+        tool="story"
+        runId={runId}
+        reason={gateReason}
+      />
+
+      {result && (
+        <p className="mt-4 text-center text-sm text-slate-600">
+          Want a blueprint built around <em>your</em> pacing?{" "}
+          <Link
+            href={`/signup?ref=tool-${SLUG}`}
+            className="font-medium text-purple-600 underline hover:text-purple-700"
+          >
+            Create a free account
+          </Link>{" "}
+          and train the AI on your own videos.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/web/components/tools/ToolResultActions.tsx
+++ b/apps/web/components/tools/ToolResultActions.tsx
@@ -2,22 +2,41 @@
 
 import { useState } from "react"
 import Link from "next/link"
-import { Check, Copy } from "lucide-react"
+import { Check, Copy, Download } from "lucide-react"
 import { Button } from "@repo/ui/button"
+import { signupHrefForRun, type FreeToolKind } from "@/lib/free-tool-session"
 
 /**
- * Copy + "what to do next" row under a generated result.
+ * Copy, export and "what to do next" under a generated result.
  *
- * The next step is always another Creator AI surface rather than a dead end, * the moment a free result lands is the only moment the visitor is certain the
- * thing works.
+ * Copy is free and instant, because the result is already on screen and making
+ * someone sign up to select text they can see would just be rude.
+ *
+ * Export is the account ask. It is the honest one: an exported file is the
+ * thing a creator takes into an editor, and it is also the moment the visitor
+ * has proof the tool works. Clicking it opens the signup gate rather than
+ * downloading, and the run travels with them so the result is in the dashboard
+ * when they arrive.
+ *
+ * The next step is always another Creator AI surface rather than a dead end, the
+ * moment a free result lands is the only moment the visitor is certain the thing
+ * works.
  */
 export default function ToolResultActions({
   copyText,
   toolSlug,
+  tool,
+  runId = null,
+  onExport,
   nextStep,
 }: {
   copyText: string
   toolSlug: string
+  /** Which real feature this result becomes once claimed. */
+  tool: FreeToolKind
+  runId?: string | null
+  /** Opens the signup gate in its "export" mood. */
+  onExport: () => void
   nextStep: { href: string; label: string }
 }) {
   const [copied, setCopied] = useState(false)
@@ -49,6 +68,11 @@ export default function ToolResultActions({
         )}
       </Button>
 
+      <Button type="button" variant="outline" size="sm" onClick={onExport}>
+        <Download className="mr-1.5 h-4 w-4" aria-hidden="true" />
+        Export
+      </Button>
+
       <Button asChild size="sm" variant="ghost" className="text-purple-700 hover:text-purple-800">
         <Link href={nextStep.href}>{nextStep.label}</Link>
       </Button>
@@ -58,7 +82,7 @@ export default function ToolResultActions({
         size="sm"
         className="ml-auto bg-gradient-to-r from-purple-500 via-indigo-500 to-cyan-500 text-white hover:brightness-110"
       >
-        <Link href={`/signup?ref=tool-${toolSlug}`}>Save it, free account</Link>
+        <Link href={signupHrefForRun(tool, toolSlug, runId)}>Save it, free account</Link>
       </Button>
     </div>
   )

--- a/apps/web/hooks/useClaimFreeRun.ts
+++ b/apps/web/hooks/useClaimFreeRun.ts
@@ -1,0 +1,67 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import { toast } from "sonner"
+import { api, getApiErrorMessage } from "@/lib/api-client"
+import { getFreeToolSession, type FreeToolKind } from "@/lib/free-tool-session"
+
+/**
+ * Picks up a `?freeRun=<id>` left by the signup flow and turns it into a real
+ * record on this user's account.
+ *
+ * The visitor generated something at /tools before they had an account. The
+ * signup link carried the run id here; the session id that authorizes the claim
+ * is still in localStorage, because /tools, /signup and /dashboard are the same
+ * origin. The API copies the stored run into the real feature table and hands
+ * back where it lives, and we replace the URL with it.
+ *
+ * Deliberately a hook shared by all three "new" pages rather than three copies:
+ * the only thing that differs between them is which page the user happened to
+ * land on, and the API already knows which table a run belongs in.
+ */
+export function useClaimFreeRun(tool: FreeToolKind) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const runId = searchParams.get("freeRun")
+  const [claiming, setClaiming] = useState(!!runId)
+  // Strict mode mounts effects twice in dev; claiming twice would be harmless
+  // (the API is idempotent per run) but would fire two requests for nothing.
+  const started = useRef(false)
+
+  useEffect(() => {
+    if (!runId || started.current) return
+    started.current = true
+
+    let cancelled = false
+    ;(async () => {
+      try {
+        const { redirectTo } = await api.post<{ redirectTo: string }>(
+          "/api/v1/free-tools/claim",
+          { runId, sessionId: getFreeToolSession() },
+          { requireAuth: true },
+        )
+        if (!cancelled) router.replace(redirectTo)
+      } catch (error) {
+        if (cancelled) return
+        // The form underneath is perfectly usable, so this is a toast and a
+        // cleared URL rather than an error page. Losing the result is bad; being
+        // stuck on a dead screen because of it is worse.
+        toast.error("Could not load your free result", {
+          description: getApiErrorMessage(
+            error,
+            "It may have already been saved to your account. Check your history.",
+          ),
+        })
+        setClaiming(false)
+        router.replace(window.location.pathname)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [runId, router, tool])
+
+  return { claiming }
+}

--- a/apps/web/hooks/useFreeTool.ts
+++ b/apps/web/hooks/useFreeTool.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react"
 import { api, getApiErrorMessage } from "@/lib/api-client"
+import { getFreeToolSession } from "@/lib/free-tool-session"
 
 /**
  * One free generation per visitor, then a signup prompt.
@@ -11,6 +12,10 @@ import { api, getApiErrorMessage } from "@/lib/api-client"
  * that is not the person the gate is for, and the per-IP window on the API is
  * the actual ceiling. Making it harder here would only punish the people who
  * came back a week later on the same laptop.
+ *
+ * Every run is also stored server-side against the visitor's session id, so the
+ * result survives the trip through /signup and can be claimed into the new
+ * account instead of being lost. `runId` is what the export CTA carries.
  *
  * ponytail: localStorage, same as the Hannah chat history. Move to a cookie if
  * the gate ever needs to be read server-side for a personalized first render.
@@ -35,17 +40,23 @@ function markUsed(tool: string) {
   }
 }
 
+/** Every free-tool response carries the id of the stored run, when it stored. */
+type WithRunId = { runId?: string | null }
+
 export function useFreeTool<TResult>(tool: string, endpoint: string) {
   const [result, setResult] = useState<TResult | null>(null)
+  const [runId, setRunId] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [showSignupGate, setShowSignupGate] = useState(false)
+  const [gateReason, setGateReason] = useState<"limit" | "export">("limit")
 
   const run = useCallback(
     async (body: Record<string, unknown>) => {
       // The gate is checked before the request, so the second attempt costs
       // nothing and the modal opens instantly.
       if (hasUsed(tool)) {
+        setGateReason("limit")
         setShowSignupGate(true)
         return
       }
@@ -53,14 +64,19 @@ export function useFreeTool<TResult>(tool: string, endpoint: string) {
       setIsLoading(true)
       setError(null)
       try {
-        const data = await api.post<TResult>(endpoint, body)
+        const data = await api.post<TResult & WithRunId>(endpoint, {
+          ...body,
+          sessionId: getFreeToolSession(),
+        })
         setResult(data)
+        setRunId(data.runId ?? null)
         markUsed(tool)
       } catch (err) {
         // A 429 means the per-IP window is spent, which is the same conversation
         // as the gate, ask for the signup rather than showing a dead end.
         const message = getApiErrorMessage(err, "That didn't generate. Please try again.")
         if ((err as { statusCode?: number })?.statusCode === 429) {
+          setGateReason("limit")
           setShowSignupGate(true)
         } else {
           setError(message)
@@ -74,10 +90,20 @@ export function useFreeTool<TResult>(tool: string, endpoint: string) {
 
   return {
     result,
+    runId,
     isLoading,
     error,
     showSignupGate,
-    openSignupGate: useCallback(() => setShowSignupGate(true), []),
+    gateReason,
+    /** Export is account-only: the file is the ask that earns the signup. */
+    requestExport: useCallback(() => {
+      setGateReason("export")
+      setShowSignupGate(true)
+    }, []),
+    openSignupGate: useCallback(() => {
+      setGateReason("limit")
+      setShowSignupGate(true)
+    }, []),
     closeSignupGate: useCallback(() => setShowSignupGate(false), []),
     run,
   }

--- a/apps/web/lib/free-tool-session.ts
+++ b/apps/web/lib/free-tool-session.ts
@@ -1,0 +1,78 @@
+/**
+ * The visitor's free-tool session id, and the signup link that carries a run
+ * through to the dashboard.
+ *
+ * The id is generated in the browser and kept in localStorage. It is what makes
+ * "sign up and keep what you just made" possible: the API stores every
+ * anonymous run against it, and the claim after signup has to present it. That
+ * also makes it the authorization for a claim, which is why it is a v4 UUID and
+ * not something derived from the visitor.
+ *
+ * Same origin throughout (/tools, /signup, /dashboard), so it survives the whole
+ * flow without a cookie or a query param.
+ */
+
+const SESSION_KEY = "free-tool-session"
+
+/** Where a claimed run of each tool should land the user. */
+export const FREE_TOOL_CLAIM_ROUTE = {
+  script: "/dashboard/scripts/new",
+  idea: "/dashboard/research/new",
+  story: "/dashboard/story-builder/new",
+} as const
+
+export type FreeToolKind = keyof typeof FREE_TOOL_CLAIM_ROUTE
+
+function uuid(): string {
+  // randomUUID needs a secure context; the fallback keeps the tools working on
+  // plain http in local dev rather than throwing where a result is on screen.
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+  return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
+    (
+      Number(c) ^
+      (crypto.getRandomValues(new Uint8Array(1))[0]! & (15 >> (Number(c) / 4)))
+    ).toString(16),
+  )
+}
+
+export function getFreeToolSession(): string {
+  try {
+    const existing = localStorage.getItem(SESSION_KEY)
+    if (existing) return existing
+    const created = uuid()
+    localStorage.setItem(SESSION_KEY, created)
+    return created
+  } catch {
+    // Storage blocked: the run is still stored server-side and still usable in
+    // this tab, it just cannot be claimed after a reload. Better than failing
+    // the generation.
+    return uuid()
+  }
+}
+
+/**
+ * The dashboard page that claims `runId`, or plain /dashboard when there is
+ * nothing to claim (the run failed to store, or storage was blocked).
+ */
+export function claimPathForRun(tool: FreeToolKind, runId: string | null): string {
+  return runId ? `${FREE_TOOL_CLAIM_ROUTE[tool]}?freeRun=${runId}` : "/dashboard"
+}
+
+/**
+ * The signup URL that brings a free result into the new account.
+ *
+ * `next` is read by /signup and by the OAuth callback, both of which only honor
+ * paths under /dashboard. The dashboard page then sees `freeRun` and claims it.
+ */
+export function signupHrefForRun(tool: FreeToolKind, toolSlug: string, runId: string | null): string {
+  const params = new URLSearchParams({ ref: `tool-${toolSlug}` })
+  if (runId) params.set("next", claimPathForRun(tool, runId))
+  return `/signup?${params.toString()}`
+}
+
+/** Same destination for someone who already has an account. */
+export function loginHrefForRun(tool: FreeToolKind, runId: string | null): string {
+  return `/login?redirectTo=${encodeURIComponent(claimPathForRun(tool, runId))}`
+}

--- a/apps/web/lib/free-tools.ts
+++ b/apps/web/lib/free-tools.ts
@@ -1,8 +1,5 @@
-import type { ComponentType } from "react";
 import type { LucideIcon } from "lucide-react";
 import { Compass, Gauge, Layers, Mic, Timer, Wand2 } from "lucide-react";
-import SearchIcon from "@/components/dashboard/sidebar/icons/SearchIcon";
-import FileTextIcon from "@/components/dashboard/sidebar/icons/FileTextIcon";
 
 /**
  * The public, no-signup tools at /tools.
@@ -11,6 +8,11 @@ import FileTextIcon from "@/components/dashboard/sidebar/icons/FileTextIcon";
  * headings, its metadata, its JSON-LD, the sitemap, and the cross-links from the
  * blog. Adding a tool means adding an object here plus a route that renders
  * ToolPageShell with its widget, no SEO wiring to remember.
+ *
+ * Data only, no React components: scripts/generate-llms.mts imports this from
+ * plain node, which resolves neither the "@/" alias nor JSX. The hub page owns
+ * the per-tool icon (see app/tools/page.tsx), which is the only place one is
+ * rendered.
  *
  * Every tool page targets a TRANSACTIONAL keyword ("...generator"), while the
  * blog posts linked from `relatedPosts` target the INFORMATIONAL versions of the
@@ -44,9 +46,6 @@ export interface FreeTool {
   slug: string;
   /** Nav/hub label, short. */
   name: string;
-  /** The icon this tool's feature uses in the dashboard sidebar, so the tool
-   *  and the paid feature it samples read as the same thing. */
-  icon: ComponentType<{ className: string }>;
   /** The ONE transactional phrase this page is optimized to rank for. */
   focusKeyword: string;
   /** Supporting long-tail terms. */
@@ -88,9 +87,8 @@ export const FREE_TOOL_SIGNUP_BENEFITS = SIGNUP_BENEFITS;
 
 export const FREE_TOOLS: FreeTool[] = [
   {
-    slug: "youtube-video-ideas-generator",
+    slug: "free-youtube-video-ideas-generator",
     name: "YouTube Video Ideas Generator",
-    icon: SearchIcon,
     focusKeyword: "youtube video ideas generator",
     keywords: [
       "free youtube video idea generator",
@@ -261,9 +259,8 @@ export const FREE_TOOLS: FreeTool[] = [
   },
 
   {
-    slug: "youtube-script-generator",
+    slug: "free-youtube-script-generator",
     name: "YouTube Script Generator",
-    icon: FileTextIcon,
     focusKeyword: "youtube script generator",
     keywords: [
       "free youtube script generator",
@@ -428,6 +425,178 @@ export const FREE_TOOLS: FreeTool[] = [
       label: "See the full script feature",
       blurb:
         "Scripts in your own voice, five languages, any length, storytelling mode, timestamps and reference files.",
+    },
+  },
+
+  {
+    slug: "free-youtube-story-structure-generator",
+    name: "YouTube Story Structure Generator",
+    focusKeyword: "youtube story structure generator",
+    keywords: [
+      "free video outline generator",
+      "youtube video structure template",
+      "retention score for youtube videos",
+      "video hook and escalation planner",
+      "story blueprint for youtube",
+    ],
+    seoTitle: "Free YouTube Story Structure Generator 2026: Plan Retention",
+    seoDescription:
+      "Free YouTube story structure generator: a hook, escalation segments, a climax and a retention score before you film. First blueprint needs no signup.",
+    h1: "Free YouTube Story Structure Generator",
+    subhead:
+      "A modular blueprint for your next video: the hook, the segments that escalate, the climax, and a retention score that says where viewers would leave. Your first one needs no account.",
+    cardDescription:
+      "Turn a topic into a beat-by-beat video structure: a 15-second hook, escalating segments with their own micro-hooks, and an honest retention score.",
+    answerSummary:
+      "A YouTube story structure generator turns a video topic into an ordered plan rather than a script: an opening hook with a promise and stakes, three to five escalation segments that each re-earn attention, a climax, a resolution, and a retention score that predicts where viewers drop off. This one builds the full blueprint from one sentence, and your first blueprint is free with no account.",
+    steps: [
+      {
+        title: "Say what the video is about",
+        description:
+          "One sentence with a point of view. \"Why your espresso tastes sour and the three things to change\" gives the model a promise to structure around; \"espresso\" does not.",
+      },
+      {
+        title: "Pick the shape",
+        description:
+          "Length, structure template (tutorial, case study, commentary, personal story and four more) and story mode. The same topic produces a very different outline as a documentary than as a high-energy breakdown.",
+      },
+      {
+        title: "Film against the beats",
+        description:
+          "You get the hook, the context setup, the escalation segments with their transitions, the climax, the resolution and a retention score. That is a shot list, not a mood board.",
+      },
+    ],
+    sections: [
+      {
+        heading: "Why an outline is not a story structure",
+        body: [
+          "Most video outlines are a list of the things you plan to say, in the order you thought of them. That is a table of contents. It tells you what is in the video and nothing about whether anyone stays for it.",
+          "A structure is different: it is a plan for *attention*. Where the curiosity gap opens, where it closes, which segment re-hooks a viewer who was about to leave, and what the payoff is that justifies the promise you made in the first fifteen seconds. This **youtube story structure generator** builds that layer, because it is the one that decides retention.",
+          "YouTube is explicit that ranking depends on how well the title, description and video content match a search, *and* on which videos drive engagement for it. Structure is the half of that sentence nobody plans. See [YouTube's own search and discovery documentation](https://support.google.com/youtube/answer/141805).",
+        ],
+      },
+      {
+        heading: "What each generated blueprint contains",
+        body: [
+          "**A hook with a promise and stakes.** Not \"open with a question\", but the exact curiosity statement, the promise the video is making, what is at risk if the viewer clicks away, a suggested opening line and what should be on screen for the first fifteen seconds.",
+          "**Context setup.** The problem, why it matters now, and the minimum background a new viewer needs before the first real point lands.",
+          "**Three to five escalation segments.** Each has its own micro-hook, the insight it delivers, an estimated duration, and the tension it hands to the next segment. This is what stops a video sagging in the middle.",
+          "**A climax and a resolution.** The biggest insight, the counter-intuitive turn, then closing the loop you opened at the start and a soft call-to-action that fits the narrative rather than interrupting it.",
+          "**A retention score.** An honest 0-10 prediction with per-section scores for curiosity density, emotional shift and information spike, plus the drop-risk rating. A section that scores badly is telling you to rewrite it before you film it, which is the cheapest moment to find out.",
+        ],
+      },
+      {
+        heading: "How to get a better blueprint out of it",
+        body: [
+          "**Name the audience level.** \"Beginner\" and \"advanced\" produce genuinely different escalation orders, because the amount of setup a viewer needs before the interesting part changes everything about pacing.",
+          "**Pick the structure template deliberately.** A topic framed as a case study escalates through investigation and findings; the same topic as a listicle escalates through ranked, standalone items. If you pick the wrong one, the blueprint says so and names a better fit.",
+          "**Be honest about the length.** The timestamps are paced to the duration you choose. Asking for a 30-minute structure and filming eight minutes gives you an outline with four segments you will cut.",
+          "**Read the low-scoring section first.** The value of a retention score is not the number at the top, it is the one section scoring 4 while everything else scores 8.",
+        ],
+      },
+      {
+        heading: "What the free version leaves out",
+        body: [
+          "This page runs a single, anonymous version of the story builder inside Creator AI. It knows your topic and the shape you picked, which is why the blueprint is solid and generic.",
+          "Inside the app, the same engine reads your channel first: your tone, your pacing, how long your segments usually run, how often you use humour, your ratio of direct address to storytelling, and the structures your best videos already used. The blueprint is then built to be filmable *by you* rather than by a generic presenter.",
+          "It also links to ideation, so a scored idea becomes a structure without retyping it, and to script writing, so the blueprint becomes a full script in your voice. The free Starter plan includes 500 credits a month and needs no card.",
+        ],
+      },
+    ],
+    connectLabel: "Connect your channel for blueprints built around your pacing",
+    benefits: [
+      {
+        icon: Timer,
+        title: "A retention score before you film",
+        description:
+          "Per-section curiosity, emotional shift and information density, with a drop-risk rating. Finding the weak segment in a document costs minutes; finding it in the analytics costs the video.",
+      },
+      {
+        icon: Layers,
+        title: "Segments that stand on their own",
+        description:
+          "Each escalation segment gets its own micro-hook and a transition that hands tension to the next one. That is also what makes a long video clippable later.",
+      },
+      {
+        icon: Wand2,
+        title: "Structure, not a mood board",
+        description:
+          "Exact opening lines, estimated durations, where the CTAs go and why. Specific enough to film from, which is the whole difference between a plan and an intention.",
+      },
+    ],
+    useCases: [
+      {
+        title: "A topic you know is good but cannot shape",
+        description:
+          "You have the idea and the research and no sense of what order any of it goes in. The blueprint gives you the order and tells you where it will sag.",
+      },
+      {
+        title: "Videos that lose people at ninety seconds",
+        description:
+          "Retention cliffs are usually a structure problem, not a delivery problem. The per-section scores point at the segment that causes it.",
+      },
+      {
+        title: "Long-form you plan to clip",
+        description:
+          "Self-contained segments with their own hooks are what a clipping tool can actually find later. Structure the long video and the Shorts come free.",
+      },
+      {
+        title: "Briefing someone else to film or edit",
+        description:
+          "Hook, beats, timings and CTA placement is already most of a brief. Hand it to an editor and skip the round of \"what did you mean here\".",
+      },
+    ],
+    faqs: [
+      {
+        question: "Is this YouTube story structure generator really free?",
+        answer:
+          "Yes. Your first blueprint generates with no account, no card and no email. Exporting it needs a free account, and so does your second blueprint. The Starter plan includes 500 credits every month and still needs no card.",
+      },
+      {
+        question: "What is the difference between this and a script generator?",
+        answer:
+          "A script is the words. A structure is the order and the pacing: where the hook lands, how each segment re-earns attention, where the payoff goes. Most creators who feel stuck writing are actually stuck structuring, which is why doing this first usually makes the script faster.",
+      },
+      {
+        question: "How is the retention score calculated?",
+        answer:
+          "The model scores each section on curiosity density, emotional shift and information spike, then rolls those into an overall 0-10 prediction and a drop-risk rating. It is a structural estimate, not a forecast of your analytics: treat a low-scoring section as a prompt to rewrite it, not as a number to optimise.",
+      },
+      {
+        question: "Which structure template should I pick?",
+        answer:
+          "Pick the one that matches how you would explain the topic out loud. If you would walk someone through steps, it is a tutorial; if you would tell them what happened to you, it is a personal story. If the model thinks you picked wrong, it names a better fit in the blueprint.",
+      },
+      {
+        question: "Can I turn the blueprint into a script?",
+        answer:
+          "Yes, inside the app. Sign up and the blueprint is saved to your dashboard, where the script writer can build on it using a voice profile trained on your own videos. On this page you get the structure itself, which is the part most outlines are missing.",
+      },
+      {
+        question: "How many free blueprints can I generate?",
+        answer:
+          "One per visit without an account. After that you will be asked to create a free account, which comes with 500 monthly credits and access to every other tool, including ideation, script writing, thumbnails, subtitles and dubbing.",
+      },
+    ],
+    relatedPosts: [
+      {
+        slug: "youtube-video-story-structure-for-retention-2026",
+        title: "YouTube Video Story Structure That Holds Retention",
+      },
+      {
+        slug: "improve-youtube-audience-retention-watch-time",
+        title: "How to Improve YouTube Audience Retention and Watch Time",
+      },
+      {
+        slug: "how-to-write-youtube-hooks-that-stop-the-scroll",
+        title: "How to Write YouTube Hooks That Stop the Scroll",
+      },
+    ],
+    upgrade: {
+      featureAnchor: "/features#story-builder",
+      label: "See the full story builder",
+      blurb:
+        "Blueprints built around your own pacing and tone, linked to your scored ideas, and handed straight to the script writer.",
     },
   },
 ];

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -106,6 +106,15 @@ const nextConfig = {
       { source: "/blog/youtube-auto-dubbing-vs-ai-voice-cloning", destination: "/blog/youtube-auto-dubbing-vs-ai-voice-cloning-explained", permanent: true },
       { source: "/blog/best-ai-dubbing-tool-for-youtubers-2026", destination: "/blog/best-ai-dubbing-tool-for-youtubers-2026-compared", permanent: true },
 
+      // Free-tool slugs gained a "free-" prefix, which is the word people
+      // actually search alongside these tools and was already the first word of
+      // both page titles. Both URLs are indexed and linked from the blog, so
+      // they 301 rather than 404. The blog bodies still point at the old paths
+      // and resolve through these; they are DB rows, and rewriting live post
+      // content to save one redirect hop is the more expensive side of the fix.
+      { source: "/tools/youtube-script-generator", destination: "/tools/free-youtube-script-generator", permanent: true },
+      { source: "/tools/youtube-video-ideas-generator", destination: "/tools/free-youtube-video-ideas-generator", permanent: true },
+
       // 2026 cluster consolidation. Eight clusters had several posts chasing one
       // search intent, which split link equity and produced the "Duplicate,
       // Google chose a different canonical" reports. Each cluster now has one

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -51,8 +51,9 @@ Creator AI runs free, anonymous versions of its generators as public web tools.
 Each gives one full generation with no signup, no credit card, and no watermark;
 output is the user's to use commercially.
 
-- [YouTube Video Ideas Generator](https://trycreatorai.com/tools/youtube-video-ideas-generator): A YouTube video ideas generator turns a topic or niche into a complete video concept instead of a bare list of titles. This one gives you a primary title plus two variations, the angle that makes it different from what already exists, a specific first-15-seconds hook, the format that suits it, target keywords, and the talking points that structure the video. Your first idea is free and needs no account.
-- [YouTube Script Generator](https://trycreatorai.com/tools/youtube-script-generator): A YouTube script generator turns a video topic into a complete, ready-to-record script rather than an outline. This one writes the hook, the sections, the transitions and the closing call-to-action, paced to the duration you choose and written in spoken rhythm so it reads naturally on camera. Pick a tone, pick a length, and your first script is free with no account.
+- [YouTube Video Ideas Generator](https://trycreatorai.com/tools/free-youtube-video-ideas-generator): A YouTube video ideas generator turns a topic or niche into a complete video concept instead of a bare list of titles. This one gives you a primary title plus two variations, the angle that makes it different from what already exists, a specific first-15-seconds hook, the format that suits it, target keywords, and the talking points that structure the video. Your first idea is free and needs no account.
+- [YouTube Script Generator](https://trycreatorai.com/tools/free-youtube-script-generator): A YouTube script generator turns a video topic into a complete, ready-to-record script rather than an outline. This one writes the hook, the sections, the transitions and the closing call-to-action, paced to the duration you choose and written in spoken rhythm so it reads naturally on camera. Pick a tone, pick a length, and your first script is free with no account.
+- [YouTube Story Structure Generator](https://trycreatorai.com/tools/free-youtube-story-structure-generator): A YouTube story structure generator turns a video topic into an ordered plan rather than a script: an opening hook with a promise and stakes, three to five escalation segments that each re-earn attention, a climax, a resolution, and a retention score that predicts where viewers drop off. This one builds the full blueprint from one sentence, and your first blueprint is free with no account.
 
 ## How Creator AI Differs from ChatGPT and Claude
 
@@ -73,6 +74,610 @@ For head-to-head comparisons see:
 ---
 
 # Full Article Corpus
+
+---
+
+## Creator AI + Opus Clip: The Shorts Workflow That Stops Burning Credits
+
+- URL: https://trycreatorai.com/blog/creator-ai-plus-opus-clip-shorts-workflow-for-youtube-2026
+- Category: Workflows
+- Focus keyword: opus clip shorts workflow
+- Summary: Opus Clip bills by the minute of source footage, not by the clip. So the cheapest way to get better Shorts is to write a long form video that already contains them.
+
+> **What is the best Opus Clip shorts workflow?** Write the long form video so it already contains standalone segments, then let Opus Clip find them. Opus Clip meters processing by the minute of source footage rather than by the clip, so a rambling ninety minute recording costs four times what a tight twenty minute one does and returns worse clips. The Opus Clip shorts workflow below moves the expensive decisions upstream into the script, where they cost nothing.
+
+![The opus clip shorts workflow starts in the story builder, not in the clipper](/story%20page.png)
+
+Almost every guide to clipping tools is a review of the clipper. That is the wrong end of the problem. The clipper is a search function, and a search function is limited by what is in the thing it searches.
+
+This is the practical version: what to change before the upload, what to pay for, and where the handoff genuinely fails.
+
+## Why the Opus Clip shorts workflow starts before you press record
+
+Opus Clip ranks its output with a Virality Score. Its [own documentation](https://help.opus.pro/docs/article/virality-score) says the score runs from 0 to 99 and that the AI weighs four things: Hook, Flow, Value and Trend. It is available on the Starter and Pro plans, not on Free.
+
+Read that list again as a creator rather than as a buyer. Hook and Flow are not properties of a clipping tool. They are properties of the recording. A hook exists because somebody wrote one. Flow exists because the segment resolves without depending on the fourteen minutes before it.
+
+So the ceiling on your clips is set before the file is uploaded. The clipper can only find the best forty seconds that exist. If the best forty seconds in your video are a mid sentence tangent, that is what you get back, scored 71, with captions on it.
+
+That is the single idea this **opus clip shorts workflow** is built around.
+
+## What Opus Clip actually charges you for
+
+Opus Clip's [pricing page](https://www.opus.pro/pricing) lists Free at $0, Starter at $15 a month, Pro at $29 a month, and a custom Business tier. Free renders up to 1080p, keeps clips for three days, and watermarks the animated caption templates. Starter and Pro export without a watermark.
+
+The part that changes how you work is the meter. Processing is billed against the length of the source video you upload, not the number of clips it returns. Ten clips from a sixty minute podcast and two clips from the same file cost the same. Confirm the current allowance on the pricing page before you commit, because these numbers move.
+
+That single fact reverses the intuition most people bring to a clipping tool. You are not paying for output. You are paying for input. Feeding it everything is the expensive habit.
+
+| Job | Opus Clip | Creator AI |
+|---|---|---|
+| Finding clip candidates in existing footage | Yes, this is the product | No |
+| Reframing horizontal to vertical with tracking | Yes | No |
+| Burned in animated captions on the clip | Yes | No |
+| Scoring a clip for likely engagement | Yes, Virality Score | No |
+| Writing the long form so clips exist | No | Yes, script and story builder |
+| Structuring for retention before filming | No | Yes, with a retention score |
+| Subtitle file for the long form upload | No | Yes, SRT you can correct |
+| Dubbing the finished video or clip | No | Yes, 29 languages |
+
+Neither column is a replacement for the other. The overlap is genuinely zero, which is rare enough to be worth saying plainly.
+
+## The seven step Opus Clip shorts workflow
+
+### Step 1: Design the long form to have seams
+
+Open the story builder and outline the video as three or four segments that each survive on their own. Each one gets a micro hook in its first sentence and finishes its own thought. The retention score tells you where the outline sags before you have filmed anything.
+
+This is the whole trick. A video built as one continuous argument has no clean cut points, and no clipper invents them.
+
+### Step 2: Write the script with the seams intact
+
+Generate the script through your trained voice profile with timestamps on. Resist the transition sentences that make a video flow beautifully and make a clip incomprehensible. "As I said earlier" is a phrase that costs you a Short.
+
+### Step 3: Record and publish the long form first
+
+The long form upload is the asset. YouTube's [search and discovery documentation](https://support.google.com/youtube/answer/141805) says videos are ranked on "How well the title, description, and video content match the viewer's search", plus engagement. The Shorts are distribution for something that already exists, not a replacement for it.
+
+Caption the long form properly while you are here. Generate the subtitles, fix the names and jargon in the editor, and upload a corrected SRT rather than trusting automatic captions.
+
+### Step 4: Upload only the minutes worth clipping
+
+Here is where the meter changes your behaviour. Do not hand Opus Clip a ninety minute stream and hope. Trim to the sections your outline already flagged as self contained, then upload that.
+
+On a sixty minute recording where twenty minutes are genuinely clippable, this is a two thirds saving on every pass, every month, forever. It is also the step almost nobody does, because uploading the whole file feels like getting more for the money.
+
+### Step 5: Sort by Virality Score, then overrule it
+
+Opus Clip sorts results by score. Treat that as a first pass filter, not a verdict. The score cannot know that clip four gives away the answer your long form video is built to withhold, or that clip seven is a client's name pronounced wrong.
+
+Watch the top eight, keep three, delete the rest. Keeping everything is how a channel ends up with forty Shorts and no identity.
+
+### Step 6: Give every Short its own title and description
+
+A Short is a video, and YouTube treats it like one. Google's [Shorts documentation](https://support.google.com/youtube/answer/10059070) confirms Shorts run up to 3 minutes and surface in search results, on the home feed, on your channel page and in subscription feeds, not only in the Shorts tab.
+
+So the clip that inherits "Podcast Ep 42 Clip 3" as a title is throwing away the one field the ranking system reads directly. Write the title for the search the clip answers. Put the link to the long form video in the description.
+
+Skip the tag box. The same YouTube page says tags are "Not important" and exist mainly to catch spelling mistakes.
+
+### Step 7: Dub the three that worked
+
+This is the step that makes the arithmetic pleasant. The free plan caps a dub at 60 seconds of source, which is a real constraint on a twelve minute video and almost none at all on a Short.
+
+Take the clip that outperformed, dub it into a second language, and upload it as its own Short on the same channel. You are testing an audience for the cost of one clip rather than one full video. Which languages are worth the effort is answered with numbers in the [dubbing ROI breakdown](/blog/is-youtube-dubbing-worth-it-roi-breakdown-2026).
+
+## The credit math nobody does before subscribing
+
+Take a creator publishing one 45 minute podcast a week.
+
+Uploading the full episode every week is 180 minutes of source a month. Uploading only the 15 minutes the outline marked as clippable is 60 minutes of source a month. Same number of usable Shorts, because the discarded 30 minutes per episode were never going to produce one.
+
+That is a plan tier of difference, bought by spending twenty minutes on an outline you should have written anyway. Every clipping tool prices this way, which is why this part of the **opus clip shorts workflow** transfers even if you switch tools later.
+
+## Where Opus Clip is better left alone
+
+Do not over apply the handoff. Several things here have no equivalent upstream:
+
+- **ReframeAnything**, which keeps a moving subject centred when converting horizontal to vertical. Doing this by hand is miserable.
+- **Burned in animated captions**, which are correct for a feed where nobody enables a caption track.
+- **ClipAnything**, which searches footage by a plain language prompt, useful for gameplay and interviews where the interesting moment is visual rather than spoken.
+- **Publishing to several platforms in one pass**, which is a real time saving and not a feature worth rebuilding.
+
+## Where this Opus Clip shorts workflow breaks
+
+**Interviews and podcasts you do not control.** If a guest rambles, no amount of upstream planning saves you. Steps 4 through 7 still apply, step 1 does not.
+
+**Captions burned into a rendered clip.** Once a clip is rendered, a wrong name is fixed by re editing and re rendering, not by editing text. Say the difficult words clearly on the day, or accept the re render.
+
+**Clips that need a hook the recording never had.** A clipper cannot write. If every candidate opens weakly, the problem is upstream and the credits you spend looking are wasted twice.
+
+**Volume as a strategy.** Shorts viewers convert to long form subscribers slowly. Three good clips a week beats twenty, and the **opus clip shorts workflow** is designed to produce three.
+
+## The short version
+
+Opus Clip is a very good search function pointed at your footage. Search functions do not create the thing they find.
+
+Write the long form so it contains three self contained segments, upload only those minutes, keep three clips, title each one for a real search, and dub the winner. That is the entire **opus clip shorts workflow**, and the expensive half of it happens in a text editor before anything is filmed. [Start free](/signup) and build the outline first.
+
+## Keep Reading
+
+- [The Best AI Tools to Turn Long Videos Into Shorts](/blog/best-ai-tools-to-turn-long-videos-into-shorts-2026)
+- [YouTube Shorts Script Generator: Hooks That Stop the Scroll](/blog/youtube-shorts-script-generator-hooks-that-stop-the-scroll-2026)
+- [YouTube Video Story Structure for Retention](/blog/youtube-video-story-structure-for-retention-2026)
+- [Creator AI + CapCut: From AI Script to Subtitled, Dubbed Video](/blog/creator-ai-plus-capcut-youtube-workflow-2026)
+- Outline it, film it, clip it. [Start free](/signup) or [see plans](/pricing).
+
+### FAQ
+
+**How does Opus Clip charge for processing?**
+By the length of the source video you upload rather than by the number of clips it returns. Ten clips and two clips from the same sixty minute file cost the same. That is why trimming to the sections worth clipping before you upload is the single highest leverage step in the workflow.
+
+**What is the Virality Score and should I trust it?**
+It is Opus Clip's 0 to 99 rating of how likely a clip is to perform, weighing Hook, Flow, Value and Trend, and it is available on the Starter and Pro plans rather than Free. Treat it as a first pass filter. It cannot know that a clip gives away the answer your long form video was built to hold back.
+
+**Do I need a script to use a clipping tool?**
+No, but the clips get better when you have one. A clipper searches for the best standalone segment that exists in the footage. If the video was written as one continuous argument with no self contained sections, there is nothing good to find, and you pay for the search either way.
+
+**Can I fix a wrong name in Opus Clip's burned in captions?**
+Not after rendering, without re editing and re rendering the clip. Burned in captions are pixels. This is the one place the workflow is genuinely unforgiving, so say difficult names and product terms clearly on the day rather than planning to fix them later.
+
+**Should each Short get its own title and description?**
+Yes. YouTube ranks on how well the title, description and video content match a search, and Shorts appear in search results as well as the Shorts feed. A clip inheriting a title like 'Episode 42 Clip 3' throws away the field the ranking system reads most directly.
+
+**Is dubbing a Short worth it?**
+It is the cheapest language test available. A Short is under three minutes, so a dub costs very little compared to a full video, and the free plan's sixty second cap is barely a constraint at that length. Dub the one clip that already outperformed rather than the whole back catalogue.
+
+
+---
+
+## Canva vs VEED: Which Browser Video Editor Is Worth Your Time?
+
+- URL: https://trycreatorai.com/blog/canva-vs-veed-which-browser-video-editor-fits-youtube-2026
+- Category: Tool Comparisons
+- Focus keyword: canva vs veed
+- Summary: Both edit video in a tab, both auto caption, both have a free plan with a catch. Here is where each one stops being good enough, and which catch is worse.
+
+> **Should I edit in Canva or VEED?** VEED if video is the only thing you make, Canva if video is one of several things you design. Both run in a browser tab, both auto caption, and both stop being enough at roughly the same point. The real **Canva vs VEED** decision is not about the timeline, it is about which free plan's catch you can live with.
+
+![canva vs veed: generating an accurate subtitle file for a long form upload](/subtitle%20page.png)
+
+These two land in the same search because they solve the same immediate problem: you have a clip, you need it captioned and exported, and you do not want to install anything.
+
+They arrive at that problem from opposite directions, which is the part worth understanding before you pick.
+
+## Canva vs VEED: a design suite that edits video, and an editor that does one thing
+
+Canva is a design platform where video is one surface among many. The timeline was added to a tool built for layouts, and it shows in both directions: shallow editing, but everything else you need for a channel is in the same tab.
+
+VEED is a video product. The timeline is the centre of gravity, and subtitles, background removal, brand kits, and AI features orbit it. Nothing about it pretends to be a poster maker.
+
+That framing explains almost every difference in the table below, and it is the whole of the **Canva vs VEED** comparison in two paragraphs.
+
+| | Canva | VEED |
+|---|---|---|
+| Primary job | Design, with a video timeline attached | Browser video editing |
+| Auto captions | Yes, free, with style packs | Yes, finer control and animation |
+| Watermark on free exports | Only on premium stock assets | Yes, on every export |
+| Free export resolution | 1080p | 720p |
+| Thumbnails, banners, end screens | Yes | Limited |
+| Brand kits | Yes, on Pro | Yes, on paid tiers |
+| Keyframes, speed curves, colour grading | No | No |
+| Comfortable video length | Short to medium | Short to medium |
+| Free plan is usable long term | Yes | No, it is a trial |
+
+## Where VEED wins
+
+**Captions as a first class feature.** Word by word animated captions, tight timing control, and style presets built for vertical video. If your output is Shorts and Reels, this is the reason to be here.
+
+**A more focused editor.** Fewer clicks between you and a cut, because the interface is not also trying to be a presentation tool.
+
+**Subtitle depth.** Translation, repositioning, and per word editing are more workable than doing the same job inside a design app.
+
+**It behaves like a video tool.** Project structure, media handling, and export options all assume video is the point, which removes a category of small frictions Canva never quite loses.
+
+## Where Canva wins
+
+**The free plan is a real plan.** This is the single most decisive item in a **Canva vs VEED** comparison for anyone not yet paying for either. VEED's free tier stamps a "Made with VEED" mark on every export, caps you at 720p, and limits both clip length and monthly export minutes. Canva watermarks premium stock assets only: your own footage, your text, and free elements export clean at 1080p. One of those is a plan. The other is a trial with a countdown.
+
+**Free auto captions with no meter.** Canva generates captions without charging AI minutes against you, with style packs and translation available. For a creator captioning several videos a week, that difference is larger than any feature gap in the editor.
+
+**Everything else a channel needs.** The thumbnail, the banner, the end screen, the community post, the sponsor deck. VEED does not compete here, and switching tabs between an editor and a design tool has a real cost measured across a year.
+
+**You probably already have it.** Canva is already open in most creators' browsers, and the marginal cost of trying its timeline is zero.
+
+Both companies re-price regularly, so confirm current tiers on [VEED's pricing page](https://www.veed.io/pricing) and [Canva's pricing page](https://www.canva.com/pricing/) rather than trusting any table, including this one.
+
+## Where both of them stop
+
+Neither tool is a real editor, and it is worth being specific about the ceiling.
+
+There is no keyframing, no speed ramping, no colour grading, no multi camera, and no serious multi track audio work in either. Both slow down noticeably once a timeline runs long, because a browser is doing work a desktop application was designed for.
+
+The practical boundary sits somewhere around ten to fifteen minutes of footage. Below it, either tool is fine and the **Canva vs VEED** choice is a preference. Above it, both start fighting you, and CapCut or a desktop editor is the honest recommendation. We walked through that handoff in the [Creator AI plus CapCut workflow](/blog/creator-ai-plus-capcut-youtube-workflow-2026).
+
+There is also a subtitle nuance worth naming. Burned in animated captions are correct for short form, where there is no caption track and no viewer settings. For a long form YouTube upload you want an actual caption file, because YouTube reads it for search and viewers can toggle it. If you are unsure which format to hand YouTube, we covered it in [SRT vs VTT explained](/blog/srt-vs-vtt-subtitle-formats-explained-2026).
+
+## So which one
+
+**Pick VEED if** short form is your output, captions are the feature you use daily, and you are willing to pay, because the free plan will not carry you.
+
+**Pick Canva if** you want one tab for the whole channel, you are not paying yet, or your videos are simple enough that a shallow timeline is not a constraint.
+
+**Pick a desktop editor if** you are consistently over fifteen minutes. Both of these will make that harder than it needs to be.
+
+## The question underneath the question
+
+Every **Canva vs VEED** comparison assumes editing is the bottleneck. For a lot of creators, it is not.
+
+If your week goes missing before you ever open an editor, staring at a blank document wondering what the video is, then a faster timeline saves you nothing. That is a writing and planning problem, and it is upstream of every tool on this page.
+
+Creator AI works on that half: it studies videos you have already published, builds a style profile from your tone and pacing, then generates topic ideas, full scripts in your voice, story structure with a retention score, subtitles, and dubbing. YouTube's own [Creator Academy](https://www.youtube.com/creators/) makes the same point in less direct language, that the decisions before the edit are what determine whether a video works.
+
+If you want that comparison drawn tool by tool, we wrote [Creator AI vs VEED](/blog/creator-ai-vs-veed-for-youtube-creators-2026) and [Creator AI vs Canva](/blog/creator-ai-vs-canva-for-youtube-thumbnails-2026).
+
+You can also check which half is broken in about a minute, with no account. The [free YouTube script generator](/tools/youtube-script-generator) turns one sentence into a complete script, and the [free video ideas generator](/tools/youtube-video-ideas-generator) turns a niche into a full concept. If either one lands, the editor was never the problem, and the **Canva vs VEED** debate was a way of avoiding a harder question.
+
+### FAQ
+
+**Is Canva or VEED better for editing YouTube videos?**
+VEED if video is the only thing you make, Canva if video is one of many things you design. VEED's editor is more focused and its free plan is more restrictive. Canva's editor is shallower but sits next to your thumbnails, banners, and community graphics, which is why most creators already have it open.
+
+**Does VEED put a watermark on free exports?**
+Yes. Every export on VEED's free plan carries a 'Made with VEED' mark, and there is no way to remove it without upgrading. The free plan also caps exports at 720p and limits video length and monthly export minutes, so it functions as a trial rather than a plan you can stay on.
+
+**Does Canva watermark videos?**
+Not for content you made from free elements. Canva watermarks premium stock assets until you pay for them or subscribe, but your own footage, text, and free elements export clean. That is the single biggest practical difference between the two free tiers.
+
+**Which has better auto captions, Canva or VEED?**
+VEED, for styled and animated captions burned into short form video, which is what it is built around. Canva's auto captions are genuinely good and free, with style packs and translation, but VEED gives you finer control over timing and appearance. For a long form upload you usually want a separate subtitle file anyway.
+
+**Can Canva or VEED replace a real video editor?**
+For simple cuts, captions, and short form, yes. Neither handles keyframing, speed ramping, colour grading, multi camera, or complex multi track audio, and both get sluggish on long timelines in a browser. Past roughly ten to fifteen minutes of footage, a desktop editor is the better tool.
+
+**Do I need either of them?**
+Only if editing is your bottleneck. Plenty of creators who feel stuck are stuck earlier, on what to make and how to say it, and a faster editor does nothing for that. Test which half is broken before you subscribe to anything.
+
+
+---
+
+## vidIQ vs Canva: Which One Does a Growing Channel Actually Need?
+
+- URL: https://trycreatorai.com/blog/vidiq-vs-canva-which-youtube-tool-do-you-actually-need-2026
+- Category: Tool Comparisons
+- Focus keyword: vidiq vs canva
+- Summary: One tells you what to make. The other makes it look clickable. A blunt look at where vidIQ and Canva overlap, where they do not, and which to pay for first.
+
+> **Is vidIQ or Canva better for a YouTube channel?** Neither, because they are not competitors. vidIQ is a research and optimisation layer that tells you what to make and how to label it. Canva is a design tool that makes the thing people click on. Almost everyone searching **vidIQ vs Canva** is really asking which one to pay for first, and the answer depends entirely on whether your problem is being found or being clicked.
+
+![vidiq vs canva: choosing the video topic before designing anything](/ideation%20page.png)
+
+This comparison shows up in search because both tools get recommended in the same breath, usually in the same "10 tools every YouTuber needs" list, with no explanation of why they are in the same sentence.
+
+They are in the same sentence because they sit next to each other in the workflow, not because you have to choose between them.
+
+## vidIQ vs Canva: two tools, two different jobs
+
+vidIQ lives on top of YouTube. Install the extension and it overlays stats onto every video you browse: views per hour, tags, SEO scores, channel data. Inside the app you get keyword research, competitor tracking, daily topic ideas, an AI coach, and a scorecard that grades your title, description, and tags before you publish. Recent versions also generate titles, descriptions, and thumbnails.
+
+Canva lives on top of a blank canvas. Templates, layers, fonts, brand kits, a stock library, and total manual control. It makes the thumbnail, the banner, the end screen, the community post, and the sponsor media kit.
+
+That is the entire **vidIQ vs Canva** distinction. One decides what the video should be. The other decides what it should look like.
+
+| | vidIQ | Canva |
+|---|---|---|
+| Keyword and topic research | Yes, its core product | No |
+| Competitor and channel analytics | Yes | No |
+| Metadata scoring before publish | Yes | No |
+| Thumbnail creation | AI generated, template led | Manual, full control |
+| Brand kits and exact fonts | No | Yes |
+| Banners, end screens, media kits | No | Yes |
+| Browser extension on YouTube | Yes | No |
+| Writes your script | Generic AI drafts | No |
+| Free tier | Limited research and AI credits | Genuinely usable |
+
+## Where vidIQ genuinely wins
+
+**It answers a question Canva cannot hear.** "Is this topic worth three days of my life?" is a research question. vidIQ gives you search demand, competition, and how similar videos performed. That is real information, even when it is only an estimate.
+
+**Competitive visibility.** Watching which videos on other channels are outperforming their baseline is the single most useful habit vidIQ enables, and the extension makes it passive rather than a chore.
+
+**Publishing hygiene.** The scorecard catches the boring mistakes: missing tags, a description that stops after one line, a title that buries the hook. Not glamorous, and it compounds.
+
+**AI features where the context already lives.** vidIQ's title and thumbnail generators are mediocre in isolation. They are useful because they already know the topic you just researched, which is a genuine advantage over pasting a prompt into a general tool.
+
+## Where Canva genuinely wins
+
+**Precision, which generative tools cannot fake.** When a thumbnail needs an exact sponsor logo, a specific hex colour, or text that must not be paraphrased, you need layers. vidIQ's generator approximates. Canva does not.
+
+**Visual consistency across a catalogue.** Brand kits, locked fonts, and saved templates are what makes a channel look like one channel across a hundred uploads. vidIQ has no answer here.
+
+**Everything that is not a thumbnail.** Banners, end screens, community graphics, merch mockups, a sponsor deck. Canva does all of it, and vidIQ does none of it.
+
+**The free tier is not a trial.** Canva Free is a working product. Most creators never pay, and the ones who do are usually buying brand kits and background removal rather than the ability to design at all. Current tiers are on [Canva's pricing page](https://www.canva.com/pricing/).
+
+## The thumbnail question, where the two actually overlap
+
+This is the only place a **vidIQ vs Canva** comparison is a real comparison, because both will make you a thumbnail.
+
+vidIQ's generator is fast and contextual. You researched the topic, so it drafts something on theme in seconds. For a mid week upload where done beats perfect, that is a reasonable trade.
+
+Canva is slower and better. Twenty minutes and full control against sixty seconds and an approximation. For the video you expect to carry the month, take the twenty minutes.
+
+YouTube's own [Creator Academy](https://www.youtube.com/creators/) treats packaging, the title and thumbnail together, as the gate that decides whether a video gets shown at all. That is a good argument for keeping a real design tool around even when a generator is more convenient. We covered what actually moves click through rate in [YouTube thumbnail mistakes killing your CTR](/blog/youtube-thumbnail-mistakes-killing-your-ctr-2026).
+
+## Cost, honestly
+
+Canva Free covers most creators forever. Canva Pro is a modest monthly fee for brand kits and a few conveniences.
+
+vidIQ is the more expensive habit. Its most useful research and its AI allowances sit on paid tiers, and the allowances are metered in a way that a normal weekly cadence burns through faster than the plan comparison suggests. Confirm current numbers on [vidIQ's pricing page](https://vidiq.com/pricing/) before you commit, because they move.
+
+So on price alone the **vidIQ vs Canva** question is not close. But price alone is the wrong lens, because you are not buying the same thing.
+
+## Which to pay for first
+
+**Pay for Canva first if** your videos get impressions and nobody clicks. That is a packaging problem, and packaging is a design problem.
+
+**Pay for vidIQ first if** your videos are good and almost nobody sees them. That is a discovery problem, and no thumbnail rescues a video that was never surfaced.
+
+**Pay for neither yet if** you are not publishing consistently. Both free tiers will carry you further than you think, and a tool subscription is the most popular way to feel productive without shipping anything.
+
+## What both of them miss
+
+Here is the uncomfortable part of every **vidIQ vs Canva** thread: neither tool makes the video.
+
+vidIQ hands you a topic. Canva hands you a thumbnail. Between those two moments is the actual work, deciding what the video says, in what order, in a voice that sounds like you, structured so a viewer stays past the first thirty seconds. That is where most channels stall, and it is the one part neither tool touches.
+
+Creator AI works in exactly that gap. It reads videos you have already published, builds a style profile from your tone, pacing, and structure, then writes scripts against it, plans the story beats, generates the subtitles, and dubs the finished video in your own voice. If you want the longer version of how that compares to each of these tools individually, we wrote [Creator AI vs vidIQ](/blog/creator-ai-vs-vidiq-for-youtube-creators-2026) and [Creator AI vs Canva](/blog/creator-ai-vs-canva-for-youtube-thumbnails-2026).
+
+You can also test the claim for free without an account. The [free YouTube script generator](/tools/youtube-script-generator) writes a complete script from one sentence. If that unblocks something a research tool and a design tool never did, you found your real bottleneck.
+
+## The short version
+
+vidIQ is the research half. Canva is the packaging half. They overlap on exactly one feature, thumbnails, and Canva wins that overlap on quality while vidIQ wins it on speed and context.
+
+Pick based on which half of your funnel is broken, keep both on their free tiers while you find out, and remember that the middle of the workflow, the video itself, is not for sale on either page.
+
+### FAQ
+
+**Is vidIQ or Canva better for YouTube?**
+Neither, because they do different jobs. vidIQ researches topics, tracks competitors, scores your metadata, and tells you what to make. Canva designs the thumbnail, banner, and end screen once you know what the video is. Most channels that grow steadily end up using both, usually on the free tiers.
+
+**Can vidIQ make thumbnails?**
+It has an AI thumbnail generator, and it is convenient because it sits inside the tool that suggested the topic. It is not a design tool though: you get a generated image rather than layers, exact fonts, and pixel level placement. For a thumbnail that has to carry a sponsored upload, Canva still wins.
+
+**Can Canva do keyword research?**
+No. Canva has no view of YouTube search volume, competitor performance, views per hour, or tags. If you want to know whether a topic is worth making, Canva has nothing to say about it. That is the whole reason these two tools coexist on the same toolbar.
+
+**Which is cheaper, vidIQ or Canva?**
+Canva, comfortably. Canva Free is a genuinely usable design tool that most creators never outgrow, while vidIQ gates its most useful research and AI allowances behind paid tiers. Check current numbers on their own pricing pages, because both re-price without much notice.
+
+**Do I need both vidIQ and Canva?**
+If you publish weekly and your topics are landing, Canva alone is often enough. If your videos are well made but nobody clicks or nobody finds them, that is a research problem, and vidIQ is the tool that speaks to it. Buying both before you know which problem you have is the common mistake.
+
+**What do vidIQ and Canva both miss?**
+The video itself. vidIQ picks the topic and Canva packages it, but neither writes the script, structures the story, or keeps a viewer watching past the first thirty seconds. That gap is where most channels actually stall, and no amount of research or design fixes it.
+
+
+---
+
+## Creator AI vs Canva: Do You Still Need a Design Tool in 2026?
+
+- URL: https://trycreatorai.com/blog/creator-ai-vs-canva-for-youtube-thumbnails-2026
+- Category: Tool Comparisons
+- Focus keyword: creator ai vs canva
+- Summary: Canva gives you total control and takes twenty minutes. Creator AI generates from your script in under one. Where each wins, and why most creators keep both.
+
+> **Can Creator AI replace Canva?** For thumbnails, often yes. For everything else Canva does, no. Canva is a general design tool that happens to make thumbnails; Creator AI is a YouTube tool that generates thumbnails from your script and your channel's style. The real **Creator AI vs Canva** question is not which one designs better, it is whether you want to design at all.
+
+![Creator AI vs Canva: AI generated YouTube thumbnails from a prompt or a video frame](/thumbnail%20page.png)
+
+Canva is on almost every creator's toolbar, and for good reason. It is the reason people who cannot design can still ship something that looks intentional.
+
+So when creators ask about **Creator AI vs Canva**, they are usually not asking which is the better product. They are asking whether they can stop opening a design tool at 1am to fight with text layers.
+
+## Creator AI vs Canva: two different jobs
+
+Canva is a manual design tool with AI features bolted on. You get a canvas, layers, fonts, a template library, and total control. The output is exactly what you assembled, which is both the strength and the cost: it is only as good as the twenty minutes you spent on it.
+
+Creator AI is a YouTube production tool where thumbnails are one output of a pipeline. You describe the thumbnail, upload a frame from your video, or hand it reference images, and it generates. There is no canvas and there are no layers.
+
+| | Creator AI | Canva |
+|---|---|---|
+| Thumbnail approach | Generative, from a prompt or frame | Manual, template plus editor |
+| Time per thumbnail | Under a minute | Ten to thirty minutes |
+| Pixel level control | No | Yes, complete |
+| Brand kit and exact fonts | No | Yes |
+| Writes your script | Yes, in your trained voice | No |
+| Video ideas and trends | Yes | No |
+| Subtitles and dubbing | Yes | No |
+| Non YouTube design work | No | Yes, everything |
+| Free tier | 500 credits per month, no card | Generous, watermark free |
+
+## Where Canva genuinely wins
+
+**Precision.** When the thumbnail has to be exact, a specific logo placement, a sponsor's brand colours, text that must not be paraphrased, you need layers. Generative tools approximate. Canva does not.
+
+**Brand consistency.** Brand kits, saved palettes, locked fonts, and reusable templates keep a channel visually coherent across a hundred uploads. Creator AI has no equivalent, and for a channel whose look is part of its identity, that is a real gap.
+
+**Everything that is not a thumbnail.** Channel banners, end screens, community posts, lower thirds, a media kit for sponsors, merch mockups. Canva does all of it. Creator AI does none of it.
+
+**It is free and genuinely good.** Canva's free tier is not a trial. Most creators never pay for it.
+
+## Where Creator AI wins
+
+**Speed, by an order of magnitude.** A thumbnail in under a minute versus twenty. Over a year of weekly uploads that is most of a working week returned to you.
+
+**It knows what the video is about.** This is the part a general design tool structurally cannot do. Creator AI generated the script, so it already knows the hook, the topic, and the promise. The thumbnail comes out of the same context instead of you translating the video into a design brief in your head.
+
+**The rest of the video.** Comparing **Creator AI vs Canva** purely on thumbnails undersells the difference, because the thumbnail is one feature. Creator AI also writes the script in your voice, generates the ideas, structures the story, produces the subtitles, and dubs the finished video. Canva does one of those, and only for the graphic.
+
+**No design skill required.** Canva lowered the floor. It did not remove it. You still need taste, and taste at 1am after editing for four hours is not most people's strong suit.
+
+## The thumbnail question, honestly
+
+Thumbnails carry more weight than almost anything else you make. YouTube's own [Creator Academy](https://www.youtube.com/creators/) puts packaging, the title and thumbnail together, at the centre of whether a video gets a chance at all.
+
+So the honest position is this: for a video where the thumbnail is the whole bet, a sponsored upload, a video you expect to carry the channel, open Canva and take the twenty minutes. Control wins when the stakes are high.
+
+For the other forty five videos a year, generative is the right trade. A good thumbnail today beats a great one you were too tired to make. We went deeper on what actually moves click through rate in [YouTube thumbnail mistakes killing your CTR](/blog/youtube-thumbnail-mistakes-killing-your-ctr-2026).
+
+## Cost
+
+Canva Free covers most creators forever. Canva Pro adds brand kits and background removal for a modest monthly fee.
+
+Creator AI's free Starter plan is 500 credits a month, no card, every feature unlocked. Thumbnails draw from the same credit pool as scripts and everything else, so heavy thumbnail months compete with heavy scripting months.
+
+Realistically, the **Creator AI vs Canva** decision is not a budget decision. Both have usable free tiers, and most creators end up on both.
+
+## Do not actually choose
+
+The most common outcome, and the one we would recommend, is using them together in a fixed order.
+
+Creator AI writes the script and generates three or four thumbnail candidates from the video's actual content. You pick the strongest one. If it needs a logo, a sponsor lockup, or exact brand type, it goes into Canva for five minutes of finishing rather than thirty minutes of building from an empty canvas.
+
+That sequence removes the blank canvas, which is the expensive part, and keeps the precision, which is the part Canva is genuinely best at. We documented the full version of this in our [Creator AI plus Canva thumbnail workflow](/blog/creator-ai-plus-canva-thumbnail-workflow-for-youtubers), which walks through the handoff step by step.
+
+## Try the writing half first
+
+If you are weighing **Creator AI vs Canva**, there is a decent chance thumbnails are not actually your bottleneck. Most creators who feel stuck are stuck earlier, on what to make and how to say it.
+
+You can check that for free and without an account. The [free YouTube script generator](/tools/youtube-script-generator) writes a complete script from a single sentence, and the [free video ideas generator](/tools/youtube-video-ideas-generator) turns a niche into a full concept. If either one solves a problem you have been carrying for months, the thumbnail was never the issue.
+
+### FAQ
+
+**Can Creator AI replace Canva for thumbnails?**
+For most uploads, yes. Creator AI generates a thumbnail from your script, a prompt, or a video frame in under a minute. For thumbnails needing exact brand colours, a sponsor logo, or precise text placement, Canva's layer level control is still better.
+
+**What can Canva do that Creator AI cannot?**
+Everything that is not a thumbnail: channel banners, end screens, community posts, sponsor media kits, and merch mockups. Canva also offers brand kits, locked fonts, saved palettes, and pixel level editing, none of which Creator AI has.
+
+**What can Creator AI do that Canva cannot?**
+Write the video. Creator AI generates trend based video ideas, writes full scripts in your trained voice, builds story structure with a retention score, produces subtitles, and dubs finished videos into other languages using your own voice. Canva does none of these.
+
+**Is Canva or Creator AI cheaper?**
+Both have real free tiers, so cost is rarely the deciding factor. Canva Free covers most creators indefinitely. Creator AI's free Starter plan gives 500 credits a month with no card and every feature unlocked, including scripts, thumbnails, subtitles, and dubbing.
+
+**Should I use Creator AI and Canva together?**
+Yes, and that is what we recommend. Let Creator AI generate thumbnail candidates from the video's actual content, pick the strongest, then finish it in Canva if it needs a logo or exact brand type. That removes the blank canvas while keeping Canva's precision.
+
+**Do I need design skills to use Creator AI thumbnails?**
+No. You describe what you want, upload a frame, or add reference images, and it generates. There is no canvas and there are no layers, which is the point: Canva lowered the barrier to designing, but it did not remove it.
+
+
+---
+
+## Creator AI vs VEED: Which One Should YouTubers Actually Pay For?
+
+- URL: https://trycreatorai.com/blog/creator-ai-vs-veed-for-youtube-creators-2026
+- Category: Tool Comparisons
+- Focus keyword: creator ai vs veed
+- Summary: VEED edits the video you already shot. Creator AI writes the one you have not. An honest breakdown of where each wins, and which to buy first if you only fund one.
+
+> **Is Creator AI a replacement for VEED?** No, and anyone telling you otherwise is selling something. VEED is a browser based video editor: you bring finished footage and cut, caption, and polish it. Creator AI works before the camera is on, turning your channel's own voice into ideas, scripts, thumbnails, and subtitles. Almost everyone who seriously compares **Creator AI vs VEED** ends up keeping both, because they own opposite halves of the same workflow.
+
+![Creator AI vs VEED: script generation in the creator's own voice](/scripts%20page.png)
+
+There is a specific moment this comparison usually happens. You signed up for VEED to add captions to a video, noticed it also has an AI script feature tucked into the sidebar, and wondered whether you can stop paying for anything else.
+
+You probably cannot, and it is worth understanding why before you cancel the wrong subscription.
+
+## Creator AI vs VEED: what each one is actually for
+
+VEED is post production. Its centre of gravity is the timeline: trimming, subtitles, background removal, brand kits, and a genuinely good browser editor that does not need a download. Everything else it offers orbits that editor.
+
+Creator AI is pre production. Its centre of gravity is your voice: it reads videos you have already published, builds a style profile from your tone, pacing, vocabulary, and structure, then writes against that profile. Everything it offers orbits that profile.
+
+That is the whole **Creator AI vs VEED** story in two sentences. One tool starts when the footage exists. The other one stops when the footage exists.
+
+| | Creator AI | VEED |
+|---|---|---|
+| Primary job | Writing and planning the video | Editing and captioning the video |
+| Learns your voice from your channel | Yes, via AI Studio | No |
+| Full script generation | Yes, in your trained voice | Yes, generic |
+| Video editing timeline | No | Yes |
+| Subtitles | Yes, generated and exported | Yes, styled and burned in |
+| Thumbnails | Yes, AI generated | Via the graphic editor |
+| Trend based video ideation | Yes | No |
+| Dubbing | Yes, in your own voice | Yes |
+| Free tier | 500 credits per month, no card | Watermarked exports, minute caps |
+
+## Where VEED genuinely wins
+
+**The editor.** If you need to cut footage in a browser, VEED is better than anything Creator AI offers, because Creator AI offers nothing there. No timeline, no trimming, no transitions.
+
+**Styled, animated captions.** VEED's word by word animated captions are a real format advantage for short form. Creator AI generates accurate subtitle files and exports them as SRT or VTT, which is what you want for long form and for YouTube's own caption track, but it is not going to burn karaoke captions onto a Short for you.
+
+**Everything in one browser tab.** For a creator whose entire process is "upload clip, caption it, export", adding a second tool is friction with no payoff.
+
+**Stock assets and brand kits.** VEED bundles a media library and brand controls that Creator AI has no equivalent for.
+
+## Where Creator AI wins
+
+**It sounds like you.** This is the only difference that really matters in a **Creator AI vs VEED** comparison, and it is not close. VEED's AI writing is a general purpose model with a video flavoured prompt. Creator AI connects to your YouTube channel, analyses videos you pick, and builds a persistent style profile. Every script after that is generated against your actual patterns instead of the internet's average.
+
+**It solves the blank page, not the blank timeline.** VEED assumes you already know what the video is. Creator AI's ideation runs live trend analysis in your niche, filters out saturated topics, scores each idea for opportunity, and runs a differentiation pass so nothing overlaps with what you have already published. There is no equivalent in VEED.
+
+**Structure before you film.** The story builder produces a blueprint with hooks, escalation points, and a retention score, so a weak video gets caught at the outline stage rather than in the edit.
+
+**Dubbing in your own voice.** Both tools dub. Creator AI clones your voice for it, so the Spanish version still sounds like your channel.
+
+**It is open source.** Creator AI is MIT licensed with the full source public, so it can be self hosted. For anyone with data residency requirements, that is the entire decision.
+
+## Pricing, honestly
+
+VEED prices on editing: [their plans](https://www.veed.io/pricing) are tiered by export quality, watermarks, and separately metered subtitle and AI minutes. The free tier watermarks your exports, which for most creators makes it a trial rather than a plan.
+
+Creator AI prices on credits. The free Starter plan is 500 credits a month with no card, and every feature is unlocked on it. The limit is volume, not capability, and nothing you export carries a watermark.
+
+Neither is expensive. If you are running both, you are looking at roughly the cost of one lunch a month for a workflow that covers ideation through to a captioned export.
+
+## Which one to buy first
+
+Every **Creator AI vs VEED** thread eventually lands on this question, and the answer depends entirely on where your week actually goes.
+
+**Buy VEED first if** your bottleneck is the edit. You know what to make, you say it fine on camera, and what eats your evening is cutting and captioning.
+
+**Buy Creator AI first if** your bottleneck is upstream of the camera. You open a blank doc and nothing comes out, or what comes out reads like a press release. That is a writing problem, and no editor fixes writing.
+
+**If your bottleneck is "I do not publish enough",** it is almost always upstream. Editing is the visible work, but the days you skipped were the ones where you never decided what to make.
+
+You can test that claim in about a minute without signing up for anything: our [free YouTube script generator](/tools/youtube-script-generator) writes a complete script from one sentence, and the [free video ideas generator](/tools/youtube-video-ideas-generator) turns a niche into a full concept with a hook and talking points. If either one unblocks you, you found your bottleneck.
+
+## Using both together
+
+The workflow that actually works looks like this.
+
+Creator AI handles ideation, the script, the story structure, and the thumbnail. You film. VEED handles the cut and the animated captions for the Short. Creator AI handles the subtitle file for the long form upload and the dubbed versions.
+
+Nothing in that sequence is duplicated, which is the tell that these are complementary tools rather than competitors. We wrote up a similar pairing in detail in our [Creator AI plus CapCut workflow](/blog/creator-ai-plus-capcut-youtube-workflow-2026), and the logic transfers directly.
+
+## The honest summary
+
+If you came here hoping one tool replaces the other, the answer is no. **Creator AI vs VEED** is not a fight, it is a division of labour, and picking the wrong one first means solving a problem you did not have.
+
+Fix the writing first if the writing is broken. Fix the edit first if the edit is broken. Most creators know which one it is, and quietly hope it is the edit, because the edit is the easier one to buy your way out of.
+
+### FAQ
+
+**Is Creator AI a replacement for VEED?**
+No. VEED is a browser based video editor for footage you have already shot, while Creator AI works before filming, generating ideas, scripts, thumbnails, and subtitles in your channel's own voice. They cover opposite halves of the workflow, and most creators who compare them keep both.
+
+**Does VEED write scripts in my voice?**
+No. VEED's AI writing uses a general purpose model, so the output reads like competent generic copy. Creator AI connects to your YouTube channel, analyses videos you select, and builds a persistent style profile from your tone, pacing, vocabulary, and structure, then writes every script against it.
+
+**Which has better subtitles, Creator AI or VEED?**
+They optimise for different things. VEED is stronger for styled, animated, burned in captions on short form. Creator AI generates accurate subtitle files and exports SRT or VTT, which is what you want for a long form upload and YouTube's own caption track.
+
+**Can Creator AI edit video?**
+No. There is no timeline, no trimming, and no transitions. If your bottleneck is the edit, VEED or CapCut is the right tool and Creator AI will not replace it.
+
+**Which should I pay for first?**
+Whichever matches your actual bottleneck. If cutting and captioning eats your evenings, buy VEED first. If you stall on what to make and how to say it, buy Creator AI first. Both have free tiers, so you can test the assumption before spending anything.
+
+**Is Creator AI open source?**
+Yes. Creator AI is MIT licensed with the full source public, so it can be self hosted with your own API keys. VEED is closed source and hosted only, so for anyone with data residency or procurement requirements this is often the deciding factor.
+
 
 ---
 
@@ -6855,191 +7460,3 @@ Act 1 (first 15%) hooks the viewer and sets the premise, Act 2 (middle 70%) deli
 
 **How do open loops improve retention?**
 An open loop teases something coming later, like 'tip #5 changed everything', creating curiosity that keeps viewers watching until you deliver the payoff.
-
----
-
-## vidIQ vs Canva: Which One Does a Growing Channel Actually Need?
-
-- URL: https://trycreatorai.com/blog/vidiq-vs-canva-which-youtube-tool-do-you-actually-need-2026
-- Category: Tool Comparisons
-- Focus keyword: vidiq vs canva
-- Summary: One tells you what to make. The other makes it look clickable. A blunt look at where vidIQ and Canva overlap, where they do not, and which to pay for first.
-
-> **Is vidIQ or Canva better for a YouTube channel?** Neither, because they are not competitors. vidIQ is a research and optimisation layer that tells you what to make and how to label it. Canva is a design tool that makes the thing people click on. Almost everyone searching **vidIQ vs Canva** is really asking which one to pay for first, and the answer depends entirely on whether your problem is being found or being clicked.
-
-![vidiq vs canva: choosing the video topic before designing anything](/ideation%20page.png)
-
-This comparison shows up in search because both tools get recommended in the same breath, usually in the same "10 tools every YouTuber needs" list, with no explanation of why they are in the same sentence.
-
-They are in the same sentence because they sit next to each other in the workflow, not because you have to choose between them.
-
-## vidIQ vs Canva: two tools, two different jobs
-
-vidIQ lives on top of YouTube. Install the extension and it overlays stats onto every video you browse: views per hour, tags, SEO scores, channel data. Inside the app you get keyword research, competitor tracking, daily topic ideas, an AI coach, and a scorecard that grades your title, description, and tags before you publish. Recent versions also generate titles, descriptions, and thumbnails.
-
-Canva lives on top of a blank canvas. Templates, layers, fonts, brand kits, a stock library, and total manual control. It makes the thumbnail, the banner, the end screen, the community post, and the sponsor media kit.
-
-That is the entire **vidIQ vs Canva** distinction. One decides what the video should be. The other decides what it should look like.
-
-| | vidIQ | Canva |
-|---|---|---|
-| Keyword and topic research | Yes, its core product | No |
-| Competitor and channel analytics | Yes | No |
-| Metadata scoring before publish | Yes | No |
-| Thumbnail creation | AI generated, template led | Manual, full control |
-| Brand kits and exact fonts | No | Yes |
-| Banners, end screens, media kits | No | Yes |
-| Browser extension on YouTube | Yes | No |
-| Writes your script | Generic AI drafts | No |
-| Free tier | Limited research and AI credits | Genuinely usable |
-
-## Where vidIQ genuinely wins
-
-**It answers a question Canva cannot hear.** "Is this topic worth three days of my life?" is a research question. vidIQ gives you search demand, competition, and how similar videos performed. That is real information, even when it is only an estimate.
-
-**Competitive visibility.** Watching which videos on other channels are outperforming their baseline is the single most useful habit vidIQ enables, and the extension makes it passive rather than a chore.
-
-**Publishing hygiene.** The scorecard catches the boring mistakes: missing tags, a description that stops after one line, a title that buries the hook. Not glamorous, and it compounds.
-
-**AI features where the context already lives.** vidIQ's title and thumbnail generators are mediocre in isolation. They are useful because they already know the topic you just researched, which is a genuine advantage over pasting a prompt into a general tool.
-
-## Where Canva genuinely wins
-
-**Precision, which generative tools cannot fake.** When a thumbnail needs an exact sponsor logo, a specific hex colour, or text that must not be paraphrased, you need layers. vidIQ's generator approximates. Canva does not.
-
-**Visual consistency across a catalogue.** Brand kits, locked fonts, and saved templates are what makes a channel look like one channel across a hundred uploads. vidIQ has no answer here.
-
-**Everything that is not a thumbnail.** Banners, end screens, community graphics, merch mockups, a sponsor deck. Canva does all of it, and vidIQ does none of it.
-
-**The free tier is not a trial.** Canva Free is a working product. Most creators never pay, and the ones who do are usually buying brand kits and background removal rather than the ability to design at all. Current tiers are on [Canva's pricing page](https://www.canva.com/pricing/).
-
-## The thumbnail question, where the two actually overlap
-
-This is the only place a **vidIQ vs Canva** comparison is a real comparison, because both will make you a thumbnail.
-
-vidIQ's generator is fast and contextual. You researched the topic, so it drafts something on theme in seconds. For a mid week upload where done beats perfect, that is a reasonable trade.
-
-Canva is slower and better. Twenty minutes and full control against sixty seconds and an approximation. For the video you expect to carry the month, take the twenty minutes.
-
-YouTube's own [Creator Academy](https://www.youtube.com/creators/) treats packaging, the title and thumbnail together, as the gate that decides whether a video gets shown at all. That is a good argument for keeping a real design tool around even when a generator is more convenient. We covered what actually moves click through rate in [YouTube thumbnail mistakes killing your CTR](/blog/youtube-thumbnail-mistakes-killing-your-ctr-2026).
-
-## Cost, honestly
-
-Canva Free covers most creators forever. Canva Pro is a modest monthly fee for brand kits and a few conveniences.
-
-vidIQ is the more expensive habit. Its most useful research and its AI allowances sit on paid tiers, and the allowances are metered in a way that a normal weekly cadence burns through faster than the plan comparison suggests. Confirm current numbers on [vidIQ's pricing page](https://vidiq.com/pricing/) before you commit, because they move.
-
-So on price alone the **vidIQ vs Canva** question is not close. But price alone is the wrong lens, because you are not buying the same thing.
-
-## Which to pay for first
-
-**Pay for Canva first if** your videos get impressions and nobody clicks. That is a packaging problem, and packaging is a design problem.
-
-**Pay for vidIQ first if** your videos are good and almost nobody sees them. That is a discovery problem, and no thumbnail rescues a video that was never surfaced.
-
-**Pay for neither yet if** you are not publishing consistently. Both free tiers will carry you further than you think, and a tool subscription is the most popular way to feel productive without shipping anything.
-
-## What both of them miss
-
-Here is the uncomfortable part of every **vidIQ vs Canva** thread: neither tool makes the video.
-
-vidIQ hands you a topic. Canva hands you a thumbnail. Between those two moments is the actual work, deciding what the video says, in what order, in a voice that sounds like you, structured so a viewer stays past the first thirty seconds. That is where most channels stall, and it is the one part neither tool touches.
-
-Creator AI works in exactly that gap. It reads videos you have already published, builds a style profile from your tone, pacing, and structure, then writes scripts against it, plans the story beats, generates the subtitles, and dubs the finished video in your own voice. If you want the longer version of how that compares to each of these tools individually, we wrote [Creator AI vs vidIQ](/blog/creator-ai-vs-vidiq-for-youtube-creators-2026) and [Creator AI vs Canva](/blog/creator-ai-vs-canva-for-youtube-thumbnails-2026).
-
-You can also test the claim for free without an account. The [free YouTube script generator](/tools/youtube-script-generator) writes a complete script from one sentence. If that unblocks something a research tool and a design tool never did, you found your real bottleneck.
-
-## The short version
-
-vidIQ is the research half. Canva is the packaging half. They overlap on exactly one feature, thumbnails, and Canva wins that overlap on quality while vidIQ wins it on speed and context.
-
-Pick based on which half of your funnel is broken, keep both on their free tiers while you find out, and remember that the middle of the workflow, the video itself, is not for sale on either page.
-
----
-
-## Canva vs VEED: Which Browser Video Editor Is Worth Your Time?
-
-- URL: https://trycreatorai.com/blog/canva-vs-veed-which-browser-video-editor-fits-youtube-2026
-- Category: Tool Comparisons
-- Focus keyword: canva vs veed
-- Summary: Both edit video in a tab, both auto caption, both have a free plan with a catch. Here is where each one stops being good enough, and which catch is worse.
-
-> **Should I edit in Canva or VEED?** VEED if video is the only thing you make, Canva if video is one of several things you design. Both run in a browser tab, both auto caption, and both stop being enough at roughly the same point. The real **Canva vs VEED** decision is not about the timeline, it is about which free plan's catch you can live with.
-
-![canva vs veed: generating an accurate subtitle file for a long form upload](/subtitle%20page.png)
-
-These two land in the same search because they solve the same immediate problem: you have a clip, you need it captioned and exported, and you do not want to install anything.
-
-They arrive at that problem from opposite directions, which is the part worth understanding before you pick.
-
-## Canva vs VEED: a design suite that edits video, and an editor that does one thing
-
-Canva is a design platform where video is one surface among many. The timeline was added to a tool built for layouts, and it shows in both directions: shallow editing, but everything else you need for a channel is in the same tab.
-
-VEED is a video product. The timeline is the centre of gravity, and subtitles, background removal, brand kits, and AI features orbit it. Nothing about it pretends to be a poster maker.
-
-That framing explains almost every difference in the table below, and it is the whole of the **Canva vs VEED** comparison in two paragraphs.
-
-| | Canva | VEED |
-|---|---|---|
-| Primary job | Design, with a video timeline attached | Browser video editing |
-| Auto captions | Yes, free, with style packs | Yes, finer control and animation |
-| Watermark on free exports | Only on premium stock assets | Yes, on every export |
-| Free export resolution | 1080p | 720p |
-| Thumbnails, banners, end screens | Yes | Limited |
-| Brand kits | Yes, on Pro | Yes, on paid tiers |
-| Keyframes, speed curves, colour grading | No | No |
-| Comfortable video length | Short to medium | Short to medium |
-| Free plan is usable long term | Yes | No, it is a trial |
-
-## Where VEED wins
-
-**Captions as a first class feature.** Word by word animated captions, tight timing control, and style presets built for vertical video. If your output is Shorts and Reels, this is the reason to be here.
-
-**A more focused editor.** Fewer clicks between you and a cut, because the interface is not also trying to be a presentation tool.
-
-**Subtitle depth.** Translation, repositioning, and per word editing are more workable than doing the same job inside a design app.
-
-**It behaves like a video tool.** Project structure, media handling, and export options all assume video is the point, which removes a category of small frictions Canva never quite loses.
-
-## Where Canva wins
-
-**The free plan is a real plan.** This is the single most decisive item in a **Canva vs VEED** comparison for anyone not yet paying for either. VEED's free tier stamps a "Made with VEED" mark on every export, caps you at 720p, and limits both clip length and monthly export minutes. Canva watermarks premium stock assets only: your own footage, your text, and free elements export clean at 1080p. One of those is a plan. The other is a trial with a countdown.
-
-**Free auto captions with no meter.** Canva generates captions without charging AI minutes against you, with style packs and translation available. For a creator captioning several videos a week, that difference is larger than any feature gap in the editor.
-
-**Everything else a channel needs.** The thumbnail, the banner, the end screen, the community post, the sponsor deck. VEED does not compete here, and switching tabs between an editor and a design tool has a real cost measured across a year.
-
-**You probably already have it.** Canva is already open in most creators' browsers, and the marginal cost of trying its timeline is zero.
-
-Both companies re-price regularly, so confirm current tiers on [VEED's pricing page](https://www.veed.io/pricing) and [Canva's pricing page](https://www.canva.com/pricing/) rather than trusting any table, including this one.
-
-## Where both of them stop
-
-Neither tool is a real editor, and it is worth being specific about the ceiling.
-
-There is no keyframing, no speed ramping, no colour grading, no multi camera, and no serious multi track audio work in either. Both slow down noticeably once a timeline runs long, because a browser is doing work a desktop application was designed for.
-
-The practical boundary sits somewhere around ten to fifteen minutes of footage. Below it, either tool is fine and the **Canva vs VEED** choice is a preference. Above it, both start fighting you, and CapCut or a desktop editor is the honest recommendation. We walked through that handoff in the [Creator AI plus CapCut workflow](/blog/creator-ai-plus-capcut-youtube-workflow-2026).
-
-There is also a subtitle nuance worth naming. Burned in animated captions are correct for short form, where there is no caption track and no viewer settings. For a long form YouTube upload you want an actual caption file, because YouTube reads it for search and viewers can toggle it. If you are unsure which format to hand YouTube, we covered it in [SRT vs VTT explained](/blog/srt-vs-vtt-subtitle-formats-explained-2026).
-
-## So which one
-
-**Pick VEED if** short form is your output, captions are the feature you use daily, and you are willing to pay, because the free plan will not carry you.
-
-**Pick Canva if** you want one tab for the whole channel, you are not paying yet, or your videos are simple enough that a shallow timeline is not a constraint.
-
-**Pick a desktop editor if** you are consistently over fifteen minutes. Both of these will make that harder than it needs to be.
-
-## The question underneath the question
-
-Every **Canva vs VEED** comparison assumes editing is the bottleneck. For a lot of creators, it is not.
-
-If your week goes missing before you ever open an editor, staring at a blank document wondering what the video is, then a faster timeline saves you nothing. That is a writing and planning problem, and it is upstream of every tool on this page.
-
-Creator AI works on that half: it studies videos you have already published, builds a style profile from your tone and pacing, then generates topic ideas, full scripts in your voice, story structure with a retention score, subtitles, and dubbing. YouTube's own [Creator Academy](https://www.youtube.com/creators/) makes the same point in less direct language, that the decisions before the edit are what determine whether a video works.
-
-If you want that comparison drawn tool by tool, we wrote [Creator AI vs VEED](/blog/creator-ai-vs-veed-for-youtube-creators-2026) and [Creator AI vs Canva](/blog/creator-ai-vs-canva-for-youtube-thumbnails-2026).
-
-You can also check which half is broken in about a minute, with no account. The [free YouTube script generator](/tools/youtube-script-generator) turns one sentence into a complete script, and the [free video ideas generator](/tools/youtube-video-ideas-generator) turns a niche into a full concept. If either one lands, the editor was never the problem, and the **Canva vs VEED** debate was a way of avoiding a harder question.

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -51,8 +51,9 @@ Creator AI runs free, anonymous versions of its generators as public web tools.
 Each gives one full generation with no signup, no credit card, and no watermark;
 output is the user's to use commercially.
 
-- [YouTube Video Ideas Generator](https://trycreatorai.com/tools/youtube-video-ideas-generator): A YouTube video ideas generator turns a topic or niche into a complete video concept instead of a bare list of titles. This one gives you a primary title plus two variations, the angle that makes it different from what already exists, a specific first-15-seconds hook, the format that suits it, target keywords, and the talking points that structure the video. Your first idea is free and needs no account.
-- [YouTube Script Generator](https://trycreatorai.com/tools/youtube-script-generator): A YouTube script generator turns a video topic into a complete, ready-to-record script rather than an outline. This one writes the hook, the sections, the transitions and the closing call-to-action, paced to the duration you choose and written in spoken rhythm so it reads naturally on camera. Pick a tone, pick a length, and your first script is free with no account.
+- [YouTube Video Ideas Generator](https://trycreatorai.com/tools/free-youtube-video-ideas-generator): A YouTube video ideas generator turns a topic or niche into a complete video concept instead of a bare list of titles. This one gives you a primary title plus two variations, the angle that makes it different from what already exists, a specific first-15-seconds hook, the format that suits it, target keywords, and the talking points that structure the video. Your first idea is free and needs no account.
+- [YouTube Script Generator](https://trycreatorai.com/tools/free-youtube-script-generator): A YouTube script generator turns a video topic into a complete, ready-to-record script rather than an outline. This one writes the hook, the sections, the transitions and the closing call-to-action, paced to the duration you choose and written in spoken rhythm so it reads naturally on camera. Pick a tone, pick a length, and your first script is free with no account.
+- [YouTube Story Structure Generator](https://trycreatorai.com/tools/free-youtube-story-structure-generator): A YouTube story structure generator turns a video topic into an ordered plan rather than a script: an opening hook with a promise and stakes, three to five escalation segments that each re-earn attention, a climax, a resolution, and a retention score that predicts where viewers drop off. This one builds the full blueprint from one sentence, and your first blueprint is free with no account.
 
 ## How Creator AI Differs from ChatGPT and Claude
 
@@ -74,17 +75,30 @@ For head-to-head comparisons see:
 
 Full text of every article below is available at https://trycreatorai.com/llms-full.txt
 
-### Use Cases
-
-- [How Agencies Scale YouTube Content Production Without Losing Voice](https://trycreatorai.com/blog/how-agencies-scale-youtube-content-production-2026): Every client channel needs a distinct voice. Freelance writers take weeks to absorb one and leave with it. A voice profile per channel changes the economics of the whole business.
-- [AI Tools for Gaming YouTubers: Scripts, Clips, and Going Global](https://trycreatorai.com/blog/best-ai-tools-for-gaming-youtubers-and-streamers-2026): Gaming has the most globally distributed audience on YouTube and the worst retention problem in long-form. Both facts point at the same underused fix.
-
 ### Workflows
 
+- [Creator AI + Opus Clip: The Shorts Workflow That Stops Burning Credits](https://trycreatorai.com/blog/creator-ai-plus-opus-clip-shorts-workflow-for-youtube-2026): Opus Clip bills by the minute of source footage, not by the clip. So the cheapest way to get better Shorts is to write a long form video that already contains them.
 - [The YouTube Video Production Checklist (45 Items, 5 Phases)](https://trycreatorai.com/blog/youtube-video-production-checklist-template): Forty-five items across ideation, pre-production, production, post, and publishing, with the ten most-skipped steps and what each one costs when you skip it.
 - [Creator AI + CapCut: From AI Script to Subtitled, Dubbed Video](https://trycreatorai.com/blog/creator-ai-plus-capcut-youtube-workflow-2026): CapCut's auto-captions guess at your jargon. Generate the subtitle track separately, fix it once, then hand CapCut a clean SRT and keep its styling. Every click, including on mobile.
 - [Creator AI + Canva: Script to Thumbnail to Published in 30 Minutes](https://trycreatorai.com/blog/creator-ai-plus-canva-thumbnail-workflow-for-youtubers): Most creators write the video, then bolt on a thumbnail. Reversing that order is a real workflow improvement: your script's cold open is your thumbnail brief.
 - [Creator AI + ChatGPT: A Two-Tool Workflow for Video Ideas](https://trycreatorai.com/blog/creator-ai-plus-chatgpt-youtube-workflow-for-video-ideas): ChatGPT gives you 40 ideas anyone could have had. Here is the six-step handoff that turns them into three that fit your channel (with the exact prompts, copy-pasteable).
+
+### Tool Comparisons
+
+- [Canva vs VEED: Which Browser Video Editor Is Worth Your Time?](https://trycreatorai.com/blog/canva-vs-veed-which-browser-video-editor-fits-youtube-2026): Both edit video in a tab, both auto caption, both have a free plan with a catch. Here is where each one stops being good enough, and which catch is worse.
+- [vidIQ vs Canva: Which One Does a Growing Channel Actually Need?](https://trycreatorai.com/blog/vidiq-vs-canva-which-youtube-tool-do-you-actually-need-2026): One tells you what to make. The other makes it look clickable. A blunt look at where vidIQ and Canva overlap, where they do not, and which to pay for first.
+- [Creator AI vs Canva: Do You Still Need a Design Tool in 2026?](https://trycreatorai.com/blog/creator-ai-vs-canva-for-youtube-thumbnails-2026): Canva gives you total control and takes twenty minutes. Creator AI generates from your script in under one. Where each wins, and why most creators keep both.
+- [Creator AI vs VEED: Which One Should YouTubers Actually Pay For?](https://trycreatorai.com/blog/creator-ai-vs-veed-for-youtube-creators-2026): VEED edits the video you already shot. Creator AI writes the one you have not. An honest breakdown of where each wins, and which to buy first if you only fund one.
+- [Creator AI vs Descript: Script-First vs Edit-First Workflows](https://trycreatorai.com/blog/creator-ai-vs-descript-for-youtube-creators): Descript is a superb post-production tool. Creator AI works before the camera turns on. Most creators buy an editor to solve a writing problem. Here is how to tell which one you have.
+- [Creator AI vs Jasper for YouTube Scripts: Copy Is Not a Script](https://trycreatorai.com/blog/creator-ai-vs-jasper-for-youtube-scripts-2026): Jasper learns your writing. Creator AI learns your talking. Why an excellent marketing-copy platform produces blog prose in a script costume, and when Jasper is still the right call.
+- [vidIQ vs TubeBuddy (2026): We Ran Both on the Same Channel](https://trycreatorai.com/blog/vidiq-vs-tubebuddy-tested-on-the-same-channel-2026): We build a competing tool and have no affiliate deal with either. Here is what 30 days of running vidIQ and TubeBuddy side by side on one channel actually showed.
+- [Creator AI vs TubeBuddy: Optimization Tool vs Production Tool](https://trycreatorai.com/blog/creator-ai-vs-tubebuddy-for-youtube-creators): TubeBuddy optimizes videos you already made. Creator AI makes them. A fair comparison of two tools that are less competitive than the search results suggest.
+- [Creator AI vs vidIQ: Which One Actually Writes in Your Voice?](https://trycreatorai.com/blog/creator-ai-vs-vidiq-for-youtube-creators-2026): vidIQ tells you what the algorithm wants. Creator AI writes it the way you would have. An honest breakdown of where each one wins, and which to buy first if you can only afford one.
+
+### Use Cases
+
+- [How Agencies Scale YouTube Content Production Without Losing Voice](https://trycreatorai.com/blog/how-agencies-scale-youtube-content-production-2026): Every client channel needs a distinct voice. Freelance writers take weeks to absorb one and leave with it. A voice profile per channel changes the economics of the whole business.
+- [AI Tools for Gaming YouTubers: Scripts, Clips, and Going Global](https://trycreatorai.com/blog/best-ai-tools-for-gaming-youtubers-and-streamers-2026): Gaming has the most globally distributed audience on YouTube and the worst retention problem in long-form. Both facts point at the same underused fix.
 
 ### Audio Dubbing
 
@@ -118,16 +132,6 @@ Full text of every article below is available at https://trycreatorai.com/llms-f
 - [7 Best Rask AI Alternatives for Video Dubbing (2026)](https://trycreatorai.com/blog/best-rask-ai-alternatives-for-video-dubbing-2026): Per-minute dubbing pricing punishes long-form creators. Here is what dubbing four 15-minute videos into three languages actually costs across seven tools, and which one fits a production workflow.
 - [8 Best TubeBuddy Alternatives in 2026 (Tested and Ranked)](https://trycreatorai.com/blog/best-tubebuddy-alternatives-for-youtube-creators-2026): Extension dependency, aggressive feature gating, a dated interface, and AI that arrived late. Eight alternatives ranked by what they actually replace, including the one feature that is genuinely hard to leave.
 - [9 Best vidIQ Alternatives for YouTube Creators (Free & Paid)](https://trycreatorai.com/blog/best-vidiq-alternatives-for-youtube-creators-2026): People leave vidIQ for four specific reasons: price creep, the AI credit ceiling, extension bloat, and scores that do not predict results. Here are nine alternatives, ranked honestly.
-
-### Tool Comparisons
-
-- [Creator AI vs Descript: Script-First vs Edit-First Workflows](https://trycreatorai.com/blog/creator-ai-vs-descript-for-youtube-creators): Descript is a superb post-production tool. Creator AI works before the camera turns on. Most creators buy an editor to solve a writing problem. Here is how to tell which one you have.
-- [Creator AI vs Jasper for YouTube Scripts: Copy Is Not a Script](https://trycreatorai.com/blog/creator-ai-vs-jasper-for-youtube-scripts-2026): Jasper learns your writing. Creator AI learns your talking. Why an excellent marketing-copy platform produces blog prose in a script costume, and when Jasper is still the right call.
-- [vidIQ vs TubeBuddy (2026): We Ran Both on the Same Channel](https://trycreatorai.com/blog/vidiq-vs-tubebuddy-tested-on-the-same-channel-2026): We build a competing tool and have no affiliate deal with either. Here is what 30 days of running vidIQ and TubeBuddy side by side on one channel actually showed.
-- [Creator AI vs TubeBuddy: Optimization Tool vs Production Tool](https://trycreatorai.com/blog/creator-ai-vs-tubebuddy-for-youtube-creators): TubeBuddy optimizes videos you already made. Creator AI makes them. A fair comparison of two tools that are less competitive than the search results suggest.
-- [Creator AI vs vidIQ: Which One Actually Writes in Your Voice?](https://trycreatorai.com/blog/creator-ai-vs-vidiq-for-youtube-creators-2026): vidIQ tells you what the algorithm wants. Creator AI writes it the way you would have. An honest breakdown of where each one wins, and which to buy first if you can only afford one.
-- [vidIQ vs Canva: Which One Does a Growing Channel Actually Need?](https://trycreatorai.com/blog/vidiq-vs-canva-which-youtube-tool-do-you-actually-need-2026): They are not competitors. vidIQ decides what the video should be, Canva decides what it should look like, they overlap on exactly one feature, and neither one makes the video.
-- [Canva vs VEED: Which Browser Video Editor Is Worth Your Time?](https://trycreatorai.com/blog/canva-vs-veed-which-browser-video-editor-fits-youtube-2026): Both edit in a tab, both auto caption, both stop being enough at the same point. The deciding factor is which free plan catch you can live with.
 
 ### YouTube Algorithm
 

--- a/packages/supabase/migrations/20260906000000_free_tool_runs.sql
+++ b/packages/supabase/migrations/20260906000000_free_tool_runs.sql
@@ -1,0 +1,72 @@
+-- Persistence for the anonymous /tools generators.
+--
+-- Until now a free run existed only in React state: the visitor generated
+-- something good, hit the signup wall, and lost it on navigation. That is the
+-- worst possible moment to lose someone, because it is the one moment they have
+-- proof the product works. This table keeps the run so signing up can hand it
+-- straight back, materialized into the real feature table.
+--
+-- ONE table for all three tools rather than three shadow tables. The rows are
+-- write-once, read-once, and the only per-tool logic is which real table a claim
+-- materializes into, which lives in code. `input`/`output` are jsonb because the
+-- shapes differ per tool and nothing here is ever queried by their contents.
+
+CREATE TABLE IF NOT EXISTS public.free_tool_runs (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  -- Client-generated UUID kept in the visitor's localStorage. Doubles as the
+  -- bearer secret for claiming: a claim must present it, so knowing a run id
+  -- (which travels in a URL) is not enough to steal someone else's work.
+  session_id uuid NOT NULL,
+  tool text NOT NULL,
+  input jsonb NOT NULL DEFAULT '{}',
+  output jsonb NOT NULL DEFAULT '{}',
+  -- Set when the visitor signs up and the run is copied into the real table.
+  claimed_by uuid,
+  claimed_at timestamptz,
+  -- Which row the claim created, so a second claim can return it instead of
+  -- inserting a duplicate. Not a FK: it points at one of three tables.
+  claimed_record_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT free_tool_runs_pkey PRIMARY KEY (id),
+  CONSTRAINT free_tool_runs_tool_check CHECK (tool IN ('script', 'idea', 'story')),
+  CONSTRAINT free_tool_runs_user_fkey FOREIGN KEY (claimed_by) REFERENCES auth.users(id) ON DELETE SET NULL,
+  -- claimed_by/claimed_at/claimed_record_id are set together or not at all.
+  CONSTRAINT free_tool_runs_claim_shape_check CHECK (
+    (claimed_by IS NULL AND claimed_at IS NULL AND claimed_record_id IS NULL)
+    OR (claimed_by IS NOT NULL AND claimed_at IS NOT NULL AND claimed_record_id IS NOT NULL)
+  )
+);
+
+-- The claim path: "every unclaimed run for this session".
+CREATE INDEX IF NOT EXISTS idx_free_tool_runs_session
+  ON public.free_tool_runs USING btree (session_id, created_at DESC)
+  WHERE claimed_by IS NULL;
+
+-- Retention sweep and the funnel report both read by age.
+CREATE INDEX IF NOT EXISTS idx_free_tool_runs_created_at
+  ON public.free_tool_runs USING btree (created_at DESC);
+
+-- RLS on with no anon policy at all: every read and write goes through the API
+-- on the service role. An anon-writable table reachable with the public key is a
+-- free Gemini-output store for anyone who reads our JS bundle, and the rows hold
+-- whatever topic a visitor typed. Nothing needs direct client access here.
+ALTER TABLE public.free_tool_runs ENABLE ROW LEVEL SECURITY;
+
+-- A signed-in user may read back the runs they claimed. Nothing more: the write
+-- and the claim are both service-role operations, because claiming has to insert
+-- into the real feature tables in the same breath.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'free_tool_runs' AND policyname = 'Users can read runs they claimed'
+  ) THEN
+    CREATE POLICY "Users can read runs they claimed"
+      ON public.free_tool_runs FOR SELECT TO authenticated
+      USING (claimed_by = auth.uid());
+  END IF;
+END $$;
+
+COMMENT ON TABLE public.free_tool_runs IS
+  'Anonymous generations from the public /tools pages, kept so signing up can materialize them into scripts / ideation_jobs / story_builder_jobs instead of losing them.';
+COMMENT ON COLUMN public.free_tool_runs.session_id IS
+  'Client-generated UUID from localStorage. Required to claim a run, so a leaked run id alone is not enough.';

--- a/packages/ui/src/utils/data.ts
+++ b/packages/ui/src/utils/data.ts
@@ -34,13 +34,18 @@ export const navItem: NavItemType[] = [
     children: [
       {
         name: "YouTube Script Generator",
-        href: "/tools/youtube-script-generator",
+        href: "/tools/free-youtube-script-generator",
         description: "A full script from one sentence, free",
       },
       {
         name: "YouTube Video Ideas Generator",
-        href: "/tools/youtube-video-ideas-generator",
+        href: "/tools/free-youtube-video-ideas-generator",
         description: "A complete video concept from a niche",
+      },
+      {
+        name: "YouTube Story Structure Generator",
+        href: "/tools/free-youtube-story-structure-generator",
+        description: "A beat-by-beat outline with a retention score",
       },
     ],
     viewAllLabel: "View all free tools",
@@ -73,8 +78,9 @@ export const footerItems: FooterSection = {
     { name: "Sign Up", href: "/signup" },
   ],
   "Free Tools": [
-    { name: "YouTube Script Generator", href: "/tools/youtube-script-generator" },
-    { name: "Video Ideas Generator", href: "/tools/youtube-video-ideas-generator" },
+    { name: "YouTube Script Generator", href: "/tools/free-youtube-script-generator" },
+    { name: "Video Ideas Generator", href: "/tools/free-youtube-video-ideas-generator" },
+    { name: "Story Structure Generator", href: "/tools/free-youtube-story-structure-generator" },
     { name: "All free tools", href: "/tools" },
   ],
   "Legal": [

--- a/packages/validations/src/consts/index.ts
+++ b/packages/validations/src/consts/index.ts
@@ -6,3 +6,5 @@ export * from './gemini';
 export * from './languages';
 export * from './upload';
 export * from './videoGeneration';
+export * from './storyBlueprint';
+export * from './storyBlueprintPrompt';

--- a/packages/validations/src/consts/storyBlueprint.ts
+++ b/packages/validations/src/consts/storyBlueprint.ts
@@ -1,0 +1,206 @@
+/**
+ * The Gemini `responseJsonSchema` for a story blueprint.
+ *
+ * Lives here rather than in the worker because two callers now need the exact
+ * same shape: the paid story-builder job, and the anonymous /tools sample whose
+ * output has to materialize into `story_builder_jobs.result` and render in the
+ * dashboard unchanged. Two copies would drift the first time a field is added,
+ * and the failure mode is a claimed blueprint with empty sections.
+ */
+export const STORY_BLUEPRINT_RESPONSE_SCHEMA = {
+  type: 'object',
+  properties: {
+    structuredBlueprint: {
+      type: 'object',
+      properties: {
+        hook: {
+          type: 'object',
+          properties: {
+            curiosityStatement: { type: 'string', description: 'A statement that sparks curiosity in the first 5 seconds' },
+            promise: { type: 'string', description: 'What the viewer will gain by watching' },
+            stakes: { type: 'string', description: 'What is at risk or why this matters now' },
+            openingLine: { type: 'string', description: 'Exact opening script line' },
+            visualSuggestion: { type: 'string', description: 'What viewer should see during hook (0-15 sec)' },
+            emotionalTrigger: { type: 'string', description: 'Primary emotion targeted' },
+          },
+          required: ['curiosityStatement', 'promise', 'stakes', 'openingLine', 'visualSuggestion', 'emotionalTrigger'],
+        },
+        contextSetup: {
+          type: 'object',
+          properties: {
+            problem: { type: 'string', description: 'The core problem or question (15-45 sec)' },
+            whyItMatters: { type: 'string', description: 'Why the viewer should care about this now' },
+            backgroundInfo: { type: 'string', description: 'Essential context to understand the topic' },
+          },
+          required: ['problem', 'whyItMatters', 'backgroundInfo'],
+        },
+        escalationSegments: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              segmentNumber: { type: 'number' },
+              title: { type: 'string' },
+              microHook: { type: 'string', description: 'Mini-hook to re-engage attention at start of segment' },
+              insight: { type: 'string', description: 'Core insight or value delivered' },
+              transitionTension: { type: 'string', description: 'How this segment creates tension leading into the next' },
+              estimatedDuration: { type: 'string' },
+            },
+            required: ['segmentNumber', 'title', 'microHook', 'insight', 'transitionTension', 'estimatedDuration'],
+          },
+          minItems: 3,
+        },
+        climax: {
+          type: 'object',
+          properties: {
+            biggestInsight: { type: 'string', description: 'The most impactful revelation' },
+            unexpectedTwist: { type: 'string', description: 'Surprising angle or counter-intuitive point' },
+            coreValueMoment: { type: 'string', description: 'The deeper meaning or takeaway' },
+          },
+          required: ['biggestInsight', 'unexpectedTwist', 'coreValueMoment'],
+        },
+        resolution: {
+          type: 'object',
+          properties: {
+            closeLoop: { type: 'string', description: 'How the opening promise is fulfilled' },
+            reinforceTransformation: { type: 'string', description: 'Restate what viewer now knows/can do' },
+            softCTA: { type: 'string', description: 'Natural call-to-action that fits the narrative' },
+          },
+          required: ['closeLoop', 'reinforceTransformation', 'softCTA'],
+        },
+      },
+      required: ['hook', 'contextSetup', 'escalationSegments', 'climax', 'resolution'],
+    },
+    tensionMapping: {
+      type: 'object',
+      properties: {
+        retentionScore: { type: 'number', description: 'Overall predicted retention 0-10' },
+        curiosityLoops: { type: 'number', description: 'Number of curiosity loops planted' },
+        emotionalPeaks: { type: 'number', description: 'Number of emotional high points' },
+        predictedDropRisk: { type: 'string', description: 'low, medium, or high' },
+        sectionScores: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              section: { type: 'string' },
+              curiosityDensity: { type: 'number', description: '0-10 score' },
+              emotionalShift: { type: 'number', description: '0-10 score' },
+              informationSpike: { type: 'number', description: '0-10 score' },
+              overallScore: { type: 'number', description: '0-10 score' },
+            },
+            required: ['section', 'curiosityDensity', 'emotionalShift', 'informationSpike', 'overallScore'],
+          },
+        },
+      },
+      required: ['retentionScore', 'curiosityLoops', 'emotionalPeaks', 'predictedDropRisk', 'sectionScores'],
+    },
+    retentionBeats: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          timestamp: { type: 'string' },
+          type: { type: 'string' },
+          description: { type: 'string' },
+        },
+        required: ['timestamp', 'type', 'description'],
+      },
+      minItems: 4,
+    },
+    openLoops: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          setup: { type: 'string' },
+          payoffTimestamp: { type: 'string' },
+          description: { type: 'string' },
+        },
+        required: ['setup', 'payoffTimestamp', 'description'],
+      },
+      minItems: 2,
+    },
+    patternInterrupts: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          timestamp: { type: 'string' },
+          type: { type: 'string' },
+          description: { type: 'string' },
+        },
+        required: ['timestamp', 'type', 'description'],
+      },
+      minItems: 4,
+    },
+    emotionalArc: {
+      type: 'object',
+      properties: {
+        structure: { type: 'string' },
+        beats: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              phase: { type: 'string' },
+              emotion: { type: 'string' },
+              timestamp: { type: 'string' },
+              description: { type: 'string' },
+            },
+            required: ['phase', 'emotion', 'timestamp', 'description'],
+          },
+          minItems: 4,
+        },
+      },
+      required: ['structure', 'beats'],
+    },
+    ctaPlacement: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          timestamp: { type: 'string' },
+          type: { type: 'string' },
+          script: { type: 'string' },
+          rationale: { type: 'string' },
+        },
+        required: ['timestamp', 'type', 'script', 'rationale'],
+      },
+      minItems: 2,
+    },
+    storyPacing: {
+      type: 'object',
+      properties: {
+        overview: { type: 'string' },
+        sections: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              duration: { type: 'string' },
+              pace: { type: 'string' },
+              description: { type: 'string' },
+            },
+            required: ['name', 'duration', 'pace', 'description'],
+          },
+          minItems: 4,
+        },
+      },
+      required: ['overview', 'sections'],
+    },
+    fullOutline: {
+      type: 'string',
+      description: 'Complete production outline incorporating all blueprint sections. Modular, not free-flow. Min 300 words.',
+    },
+    detectedContentType: {
+      type: 'string',
+      description: 'AI-detected best content type for this topic if different from user selection',
+    },
+  },
+  required: [
+    'structuredBlueprint', 'tensionMapping', 'retentionBeats', 'openLoops',
+    'patternInterrupts', 'emotionalArc', 'ctaPlacement', 'storyPacing', 'fullOutline',
+  ],
+} as const;

--- a/packages/validations/src/consts/storyBlueprintPrompt.ts
+++ b/packages/validations/src/consts/storyBlueprintPrompt.ts
@@ -1,0 +1,93 @@
+/**
+ * The story-blueprint prompt spine, shared by the paid worker job and the
+ * anonymous /tools sample.
+ *
+ * Only the creator-profile block differs between the two: the paid job appends
+ * one built from `user_style` + `youtube_channels`, the free sample has no
+ * channel to read and appends nothing. Everything else, the story-mode
+ * definitions, the structure templates and the numbered requirements, is what
+ * makes the model fill STORY_BLUEPRINT_RESPONSE_SCHEMA correctly, so it lives
+ * in one place. A second copy would drift, and a drifted free prompt produces a
+ * blueprint that renders with holes once it is claimed into the dashboard.
+ */
+
+export interface StoryBlueprintPromptInput {
+  videoTopic: string;
+  /** Pre-resolved display labels, e.g. VIDEO_DURATION_LABELS[videoDuration]. */
+  durationLabel: string;
+  contentLabel: string;
+  storyModeLabel: string;
+  audienceLevel: string;
+  targetAudience?: string;
+  tone?: string;
+  additionalContext?: string;
+  ideationContext?: string;
+  /** The paid job's creator-style block. Omitted for anonymous runs. */
+  creatorSection?: string;
+}
+
+export function buildStoryBlueprintPrompt({
+  videoTopic,
+  durationLabel,
+  contentLabel,
+  storyModeLabel,
+  audienceLevel,
+  targetAudience,
+  tone,
+  additionalContext,
+  ideationContext,
+  creatorSection,
+}: StoryBlueprintPromptInput): string {
+  return `You are an expert YouTube content strategist specializing in story structure and retention optimization. Generate a comprehensive, MODULAR (not free-flow) story blueprint.
+
+**Video Topic:** ${videoTopic}
+**Structure Template:** ${contentLabel}
+**Story Mode:** ${storyModeLabel}
+**Video Duration:** ${durationLabel}
+**Audience Level:** ${audienceLevel}
+${targetAudience ? `**Target Audience:** ${targetAudience}` : ''}
+${tone ? `**Desired Tone:** ${tone}` : ''}
+${additionalContext ? `**Additional Context:** ${additionalContext}` : ''}
+${ideationContext ? `**Idea Context from Ideation:** ${ideationContext}` : ''}
+${creatorSection ?? ''}
+
+STORY MODE "${storyModeLabel}" means:
+- Cinematic: Dramatic visuals, slow reveals, epic tone, wide establishing shots
+- High-Energy: Fast cuts, bold statements, rapid pacing, high intensity
+- Documentary: Facts-first, interviews-style, measured pacing, authoritative
+- Conversational: Casual, direct-to-camera, personal, relatable, as if talking to a friend
+- Dramatic: Tension-heavy, cliffhangers, emotional peaks, suspenseful reveals
+- Minimal: Clean, simple, essential info only, no fluff, elegant pacing
+
+STRUCTURE TEMPLATE "${contentLabel}" shapes the escalation segments:
+- Educational Breakdown: Progressive complexity, concept stacking
+- Commentary: Opinion-led, reaction-driven, hot takes with evidence
+- Documentary: Evidence gathering → reveal → impact → implications
+- Case Study: Setup → investigation → findings → lessons → application
+- Personal Story: Situation → struggle → turning point → transformation
+- Listicle: Ranked items with escalating value, each standalone
+- Tutorial: Setup → step-by-step → common mistakes → pro tips
+
+REQUIREMENTS:
+1. **Structured Blueprint** must be MODULAR with:
+   - Hook (0-15 sec): curiosity statement, promise, stakes
+   - Context Setup (15-45 sec): problem, why it matters
+   - Escalation: 3-5 segments, each with micro-hook, insight, transition tension
+   - Climax: biggest insight, unexpected twist, core value moment
+   - Resolution + Callback: close loop, reinforce transformation, soft CTA
+
+2. **Tension Mapping** must calculate:
+   - retentionScore (0-10 overall)
+   - curiosityLoops count
+   - emotionalPeaks count
+   - predictedDropRisk (low/medium/high)
+   - Per-section scores for curiosityDensity, emotionalShift, informationSpike (each 0-10)
+
+3. Retention beats (4-6), open loops (2-4), pattern interrupts (4-6), emotional arc (4-6 phases), CTAs (2-3, never first 30s), pacing sections (4-6)
+
+4. fullOutline must be modular and detailed (300+ words), not free-flow text
+
+5. If the chosen content type doesn't fit the topic well, suggest a better one in detectedContentType
+
+6. All timestamps must be realistic for ${durationLabel}`;
+}

--- a/packages/workers/src/processor/story-builder.processor.ts
+++ b/packages/workers/src/processor/story-builder.processor.ts
@@ -14,6 +14,8 @@ import {
   calculateStoryBuilderCredits,
   STORY_BUILDER_CREDIT_MULTIPLIER,
   TOKENS_PER_CREDIT,
+  STORY_BLUEPRINT_RESPONSE_SCHEMA,
+  buildStoryBlueprintPrompt,
 } from '@repo/validation';
 import { GoogleGenAI } from '@google/genai';
 import { getGenAI, GEMINI_TEXT_MODEL } from './utils/genai';
@@ -57,204 +59,6 @@ interface ChannelData {
   topic_details: any;
   default_language: string | null;
 }
-
-const BLUEPRINT_RESPONSE_SCHEMA = {
-  type: 'object',
-  properties: {
-    structuredBlueprint: {
-      type: 'object',
-      properties: {
-        hook: {
-          type: 'object',
-          properties: {
-            curiosityStatement: { type: 'string', description: 'A statement that sparks curiosity in the first 5 seconds' },
-            promise: { type: 'string', description: 'What the viewer will gain by watching' },
-            stakes: { type: 'string', description: 'What is at risk or why this matters now' },
-            openingLine: { type: 'string', description: 'Exact opening script line' },
-            visualSuggestion: { type: 'string', description: 'What viewer should see during hook (0-15 sec)' },
-            emotionalTrigger: { type: 'string', description: 'Primary emotion targeted' },
-          },
-          required: ['curiosityStatement', 'promise', 'stakes', 'openingLine', 'visualSuggestion', 'emotionalTrigger'],
-        },
-        contextSetup: {
-          type: 'object',
-          properties: {
-            problem: { type: 'string', description: 'The core problem or question (15-45 sec)' },
-            whyItMatters: { type: 'string', description: 'Why the viewer should care about this now' },
-            backgroundInfo: { type: 'string', description: 'Essential context to understand the topic' },
-          },
-          required: ['problem', 'whyItMatters', 'backgroundInfo'],
-        },
-        escalationSegments: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              segmentNumber: { type: 'number' },
-              title: { type: 'string' },
-              microHook: { type: 'string', description: 'Mini-hook to re-engage attention at start of segment' },
-              insight: { type: 'string', description: 'Core insight or value delivered' },
-              transitionTension: { type: 'string', description: 'How this segment creates tension leading into the next' },
-              estimatedDuration: { type: 'string' },
-            },
-            required: ['segmentNumber', 'title', 'microHook', 'insight', 'transitionTension', 'estimatedDuration'],
-          },
-          minItems: 3,
-        },
-        climax: {
-          type: 'object',
-          properties: {
-            biggestInsight: { type: 'string', description: 'The most impactful revelation' },
-            unexpectedTwist: { type: 'string', description: 'Surprising angle or counter-intuitive point' },
-            coreValueMoment: { type: 'string', description: 'The deeper meaning or takeaway' },
-          },
-          required: ['biggestInsight', 'unexpectedTwist', 'coreValueMoment'],
-        },
-        resolution: {
-          type: 'object',
-          properties: {
-            closeLoop: { type: 'string', description: 'How the opening promise is fulfilled' },
-            reinforceTransformation: { type: 'string', description: 'Restate what viewer now knows/can do' },
-            softCTA: { type: 'string', description: 'Natural call-to-action that fits the narrative' },
-          },
-          required: ['closeLoop', 'reinforceTransformation', 'softCTA'],
-        },
-      },
-      required: ['hook', 'contextSetup', 'escalationSegments', 'climax', 'resolution'],
-    },
-    tensionMapping: {
-      type: 'object',
-      properties: {
-        retentionScore: { type: 'number', description: 'Overall predicted retention 0-10' },
-        curiosityLoops: { type: 'number', description: 'Number of curiosity loops planted' },
-        emotionalPeaks: { type: 'number', description: 'Number of emotional high points' },
-        predictedDropRisk: { type: 'string', description: 'low, medium, or high' },
-        sectionScores: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              section: { type: 'string' },
-              curiosityDensity: { type: 'number', description: '0-10 score' },
-              emotionalShift: { type: 'number', description: '0-10 score' },
-              informationSpike: { type: 'number', description: '0-10 score' },
-              overallScore: { type: 'number', description: '0-10 score' },
-            },
-            required: ['section', 'curiosityDensity', 'emotionalShift', 'informationSpike', 'overallScore'],
-          },
-        },
-      },
-      required: ['retentionScore', 'curiosityLoops', 'emotionalPeaks', 'predictedDropRisk', 'sectionScores'],
-    },
-    retentionBeats: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          timestamp: { type: 'string' },
-          type: { type: 'string' },
-          description: { type: 'string' },
-        },
-        required: ['timestamp', 'type', 'description'],
-      },
-      minItems: 4,
-    },
-    openLoops: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          setup: { type: 'string' },
-          payoffTimestamp: { type: 'string' },
-          description: { type: 'string' },
-        },
-        required: ['setup', 'payoffTimestamp', 'description'],
-      },
-      minItems: 2,
-    },
-    patternInterrupts: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          timestamp: { type: 'string' },
-          type: { type: 'string' },
-          description: { type: 'string' },
-        },
-        required: ['timestamp', 'type', 'description'],
-      },
-      minItems: 4,
-    },
-    emotionalArc: {
-      type: 'object',
-      properties: {
-        structure: { type: 'string' },
-        beats: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              phase: { type: 'string' },
-              emotion: { type: 'string' },
-              timestamp: { type: 'string' },
-              description: { type: 'string' },
-            },
-            required: ['phase', 'emotion', 'timestamp', 'description'],
-          },
-          minItems: 4,
-        },
-      },
-      required: ['structure', 'beats'],
-    },
-    ctaPlacement: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          timestamp: { type: 'string' },
-          type: { type: 'string' },
-          script: { type: 'string' },
-          rationale: { type: 'string' },
-        },
-        required: ['timestamp', 'type', 'script', 'rationale'],
-      },
-      minItems: 2,
-    },
-    storyPacing: {
-      type: 'object',
-      properties: {
-        overview: { type: 'string' },
-        sections: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              name: { type: 'string' },
-              duration: { type: 'string' },
-              pace: { type: 'string' },
-              description: { type: 'string' },
-            },
-            required: ['name', 'duration', 'pace', 'description'],
-          },
-          minItems: 4,
-        },
-      },
-      required: ['overview', 'sections'],
-    },
-    fullOutline: {
-      type: 'string',
-      description: 'Complete production outline incorporating all blueprint sections. Modular, not free-flow. Min 300 words.',
-    },
-    detectedContentType: {
-      type: 'string',
-      description: 'AI-detected best content type for this topic if different from user selection',
-    },
-  },
-  required: [
-    'structuredBlueprint', 'tensionMapping', 'retentionBeats', 'openLoops',
-    'patternInterrupts', 'emotionalArc', 'ctaPlacement', 'storyPacing', 'fullOutline',
-  ],
-} as const;
 
 @Processor('story-builder', { concurrency: 3 })
 export class StoryBuilderProcessor extends WorkerHost {
@@ -331,7 +135,7 @@ export class StoryBuilderProcessor extends WorkerHost {
         contents: [{ role: 'user', parts: [{ text: prompt }] }],
         config: {
           responseMimeType: 'application/json',
-          responseJsonSchema: BLUEPRINT_RESPONSE_SCHEMA,
+          responseJsonSchema: STORY_BLUEPRINT_RESPONSE_SCHEMA,
         },
       });
 
@@ -413,6 +217,10 @@ export class StoryBuilderProcessor extends WorkerHost {
     }
   }
 
+  /**
+   * Only the creator-profile block is built here. The rest of the prompt is
+   * shared with the anonymous /tools sample so the two cannot drift.
+   */
   private buildPrompt(
     videoTopic: string,
     targetAudience: string,
@@ -454,58 +262,18 @@ ${pacingSection}
 IMPORTANT: Adapt ALL elements to match this creator's established style.
 ---` : '';
 
-    return `You are an expert YouTube content strategist specializing in story structure and retention optimization. Generate a comprehensive, MODULAR (not free-flow) story blueprint.
-
-**Video Topic:** ${videoTopic}
-**Structure Template:** ${contentLabel}
-**Story Mode:** ${storyModeLabel}
-**Video Duration:** ${durationLabel}
-**Audience Level:** ${audienceLevel}
-${targetAudience ? `**Target Audience:** ${targetAudience}` : ''}
-${tone ? `**Desired Tone:** ${tone}` : ''}
-${additionalContext ? `**Additional Context:** ${additionalContext}` : ''}
-${ideationContext ? `**Idea Context from Ideation:** ${ideationContext}` : ''}
-${creatorSection}
-
-STORY MODE "${storyModeLabel}" means:
-- Cinematic: Dramatic visuals, slow reveals, epic tone, wide establishing shots
-- High-Energy: Fast cuts, bold statements, rapid pacing, high intensity
-- Documentary: Facts-first, interviews-style, measured pacing, authoritative
-- Conversational: Casual, direct-to-camera, personal, relatable, as if talking to a friend
-- Dramatic: Tension-heavy, cliffhangers, emotional peaks, suspenseful reveals
-- Minimal: Clean, simple, essential info only, no fluff, elegant pacing
-
-STRUCTURE TEMPLATE "${contentLabel}" shapes the escalation segments:
-- Educational Breakdown: Progressive complexity, concept stacking
-- Commentary: Opinion-led, reaction-driven, hot takes with evidence
-- Documentary: Evidence gathering → reveal → impact → implications
-- Case Study: Setup → investigation → findings → lessons → application
-- Personal Story: Situation → struggle → turning point → transformation
-- Listicle: Ranked items with escalating value, each standalone
-- Tutorial: Setup → step-by-step → common mistakes → pro tips
-
-REQUIREMENTS:
-1. **Structured Blueprint** must be MODULAR with:
-   - Hook (0-15 sec): curiosity statement, promise, stakes
-   - Context Setup (15-45 sec): problem, why it matters
-   - Escalation: 3-5 segments, each with micro-hook, insight, transition tension
-   - Climax: biggest insight, unexpected twist, core value moment
-   - Resolution + Callback: close loop, reinforce transformation, soft CTA
-
-2. **Tension Mapping** must calculate:
-   - retentionScore (0-10 overall)
-   - curiosityLoops count
-   - emotionalPeaks count
-   - predictedDropRisk (low/medium/high)
-   - Per-section scores for curiosityDensity, emotionalShift, informationSpike (each 0-10)
-
-3. Retention beats (4-6), open loops (2-4), pattern interrupts (4-6), emotional arc (4-6 phases), CTAs (2-3, never first 30s), pacing sections (4-6)
-
-4. fullOutline must be modular and detailed (300+ words), not free-flow text
-
-5. If the chosen content type doesn't fit the topic well, suggest a better one in detectedContentType
-
-6. All timestamps must be realistic for ${durationLabel}`;
+    return buildStoryBlueprintPrompt({
+      videoTopic,
+      durationLabel,
+      contentLabel,
+      storyModeLabel,
+      audienceLevel,
+      targetAudience,
+      tone,
+      additionalContext,
+      ideationContext,
+      creatorSection,
+    });
   }
 
   private async updateJobStatus(jobId: string, status: string, errorMessage?: string) {


### PR DESCRIPTION
A visitor generates something good on a `/tools` page and currently loses it the moment they hit the signup wall. That is the worst possible moment to lose someone: it is the one moment they have proof the product works. This PR closes that, and adds the story builder as the third free tool.

## 1. New free tool

`/tools/free-youtube-story-structure-generator` runs the same engine as the paid story builder, minus the creator style profile (there is no connected channel to read).

It generates the **full** blueprint schema rather than a trimmed preview, on purpose: the public page renders only the hook, the escalation segments, the climax/resolution and the retention score, but a claimed run has to drop into `story_builder_jobs.result` untouched. A trimmed sample would claim into a dashboard page with empty sections. Everything the page does not show is the pull to sign up.

## 2. Every free run is now stored

New table `public.free_tool_runs` (`20260906000000_free_tool_runs.sql`). One table for all three tools rather than three shadow tables: the rows are write-once/read-once, and the only per-tool logic is which real table a claim materializes into, which lives in code.

- `session_id` is a client-generated UUID kept in localStorage. It doubles as the bearer secret for claiming, so knowing a run id (which travels in a URL) is not enough to take someone else's work.
- RLS on, with no anon policy. Writes and claims go through the API on the service role; a signed-in user may read back only runs they claimed.
- Recording is **best effort**. A DB failure logs and returns null rather than turning a working generator into an error page.

## 3. Export is the account ask

Copy stays free (the text is already on screen; making someone sign up to select it would just be rude). **Export** opens the signup gate in a new "export" mood, and the run travels with the visitor:

```
Export → /signup?ref=tool-…&next=/dashboard/story-builder/new?freeRun=<id>
       → auth callback (already narrows `next` to /dashboard paths)
       → dashboard sees ?freeRun=, POSTs /free-tools/claim with the session id
       → API copies the run into scripts / ideation_jobs / story_builder_jobs
       → router.replace onto the real record
```

They land on a normal record with normal history, not a special "imported" one. Claiming is idempotent per run, so refreshing a `?freeRun=` URL is harmless.

## Supporting changes

**Tool slugs gained a `free-` prefix**, as requested, with 301s from both old URLs in `next.config.mjs`. The blog bodies still point at the old paths and resolve through those redirects: they are DB rows, and rewriting live post content to save one redirect hop is the more expensive side of the fix.

| Before | After |
|---|---|
| `/tools/youtube-script-generator` | `/tools/free-youtube-script-generator` |
| `/tools/youtube-video-ideas-generator` | `/tools/free-youtube-video-ideas-generator` |
| — | `/tools/free-youtube-story-structure-generator` |

**The blueprint response schema and prompt spine moved to `@repo/validation`**, imported by both the worker and the anonymous sample. Two copies would drift the first time a field is added, and a drifted free prompt produces a blueprint that renders with holes once it is claimed. The worker's `buildPrompt` now only builds the creator-profile block and delegates the rest (`story-builder.processor.ts` drops ~270 lines).

**`/signup` now honors `?next=`**, through both Google OAuth and the email confirmation link. Nothing new is trusted: the auth callback already narrowed `next` to `/dashboard` paths before honoring it.

**The claim endpoint is behind `SupabaseAuthGuard` without `OnboardedGuard`**, deliberately. It runs seconds after signup, when the user has neither a trained AI nor a connected channel, and it spends no credits. The dashboard read routes it redirects to are gated the same way.

**`lib/free-tools.ts` is data only now.** It imported React icon components via the `@/` alias, which made it unloadable from `scripts/generate-llms.mts` and had quietly broken the `llms.txt` generator (since "use the dashboard sidebar icons on the tool cards"). The hub page owns the per-tool icon, which is the only place one renders. `llms.txt` / `llms-full.txt` are regenerated here.

## Verification

- **22 API tests pass** (`free-tools.controller.spec.ts` + a new `free-tool-runs.service.spec.ts` covering the claim row mapping, which is the part that fails silently: a missing field shows up as an empty dashboard panel, not an error).
- `tsc --noEmit` clean on api, web and workers.
- `next build` compiles and generates all 125 pages.
- Driven in a browser end to end against a live dev server: the blueprint generated (retention 8.9/10, 3 escalation segments), the export gate opens with the signup ask, the hub page renders all three tools with icons intact, and `/tools/youtube-script-generator` 301s to the new slug.

## Before merging

The migration has **not** been applied to the shared Supabase project. Until it is, runs fail to store and fall back gracefully (the result renders, there is no run id, and no claim link is offered) — I verified that path rather than applying a schema change to a shared database without asking. Applying it turns the claim flow on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
