### PR TITLE
feat(web): PeerPush badge in the footer

### DIFF
--- a/apps/web/components/footer.tsx
+++ b/apps/web/components/footer.tsx
@@ -112,6 +112,15 @@ const Footer = () => {
                   href: item.href,
                 }))}
               />
+              <a href="https://peerpush.com/p/creator-ai" target="_blank" rel="noopener" className="inline-block">
+                <img
+                  src="https://peerpush.com/p/creator-ai/badge.png"
+                  alt="Creator AI on PeerPush"
+                  width={230}
+                  height={65}
+                  className="w-[230px] max-w-full h-auto"
+                />
+              </a>
             </motion.div>
 
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-6">

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -30,7 +30,7 @@ const contentSecurityPolicy = [
   // <style> tags by design.
   `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""} https://www.googletagmanager.com https://lmsqueezy.com https://app.lemonsqueezy.com`,
   "style-src 'self' 'unsafe-inline'",
-  `img-src 'self' data: blob: https://avatar.vercel.sh https://yt3.ggpht.com https://i.ytimg.com https://www.google-analytics.com ${supabaseUrl}`,
+  `img-src 'self' data: blob: https://avatar.vercel.sh https://yt3.ggpht.com https://i.ytimg.com https://www.google-analytics.com https://peerpush.com ${supabaseUrl}`,
   "font-src 'self' data:",
   `connect-src 'self' ${supabaseUrl} ${supabaseWs} ${backendUrl} https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com`,
   // Demo video (Drive) and the checkout overlay.


### PR DESCRIPTION
Adds the PeerPush badge to the marketing footer, under the social dock in the left column.

Two details beyond the snippet PeerPush hands out:

- **Sized from the real asset.** The badge is 460×130 intrinsic, so it renders at 230×65 with explicit `width`/`height`. Without them the footer reflows when the image lands.
- **CSP.** `peerpush.com` added to `img-src` in `next.config.mjs`. The policy ships report-only today, so the badge works either way — but it would have logged a violation now and gone blank the moment the policy is enforced.

Plain `<img>` rather than `next/image`, matching the other remote images in the app and avoiding a `remotePatterns` entry for one badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)