### PR TITLE
Draft thumbnail prompts from the creator style and the source feature

### DIFF
--- a/apps/api/src/dubbing/dubbing.service.spec.ts
+++ b/apps/api/src/dubbing/dubbing.service.spec.ts
@@ -9,7 +9,12 @@ import { ConfigService } from '@nestjs/config';
 import { getQueueToken } from '@nestjs/bullmq';
 import { DubbingService } from './dubbing.service';
 import { SupabaseService } from '../supabase/supabase.service';
-import { DUBBING_CANCEL_PREFIX } from '@repo/validation';
+import {
+  DUBBING_CANCEL_PREFIX,
+  DUBBING_CREDIT_MULTIPLIER,
+  calculateDubbingCreditsByDuration,
+  getMinimumCreditsForDubbing,
+} from '@repo/validation';
 import { deleteGcsObject, moveGcsObject } from '../utils';
 
 jest.mock('../utils', () => ({
@@ -36,6 +41,16 @@ function chain(result: unknown) {
 }
 
 const USER = 'user-1';
+
+// Every fixture dub here is the same length, and its price is whatever the current
+// rate makes it — derived, not written down, so a repricing (see the
+// DUBBING_CREDIT_MULTIPLIER promo note) moves the expectations with it instead of
+// leaving them asserting last quarter's price. The suite runs on 'Creator', a paid
+// plan, so the paid multiplier applies.
+const DUB_SECONDS = 30;
+const DUB_COST = calculateDubbingCreditsByDuration(DUB_SECONDS, DUBBING_CREDIT_MULTIPLIER);
+// One second's worth: the most a balance can hold and still not cover the clip.
+const DUB_FLOOR = getMinimumCreditsForDubbing(DUBBING_CREDIT_MULTIPLIER);
 
 describe('DubbingService', () => {
   let service: DubbingService;
@@ -103,7 +118,7 @@ describe('DubbingService', () => {
   });
 
   describe('signUpload', () => {
-    const input = { filename: 'a.mp3', contentType: 'audio/mpeg', fileSize: 1000, isVideo: false, durationSeconds: 30 };
+    const input = { filename: 'a.mp3', contentType: 'audio/mpeg', fileSize: 1000, isVideo: false, durationSeconds: DUB_SECONDS };
 
     it('accepts a Starter clip within the 60s cap', async () => {
       await build({ subscriptions: chain(planResult('Starter')) });
@@ -144,7 +159,7 @@ describe('DubbingService', () => {
     // Regression: the balance was only checked at createDub, so a user short on credits
     // pushed up to 500MB to GCS and was only then told they could not afford it.
     it('rejects an unaffordable dub before the upload starts', async () => {
-      await build({ profiles: chain({ data: { credits: 10 }, error: null }) });
+      await build({ profiles: chain({ data: { credits: DUB_FLOOR }, error: null }) });
       await expect(service.signUpload(input, USER)).rejects.toThrow(ForbiddenException);
     });
   });
@@ -155,7 +170,7 @@ describe('DubbingService', () => {
       targetLanguage: 'es',
       isVideo: false,
       mediaName: 'My clip',
-      durationSeconds: 30,
+      durationSeconds: DUB_SECONDS,
     };
 
     it("rejects an object outside the user's prefix", async () => {
@@ -174,14 +189,16 @@ describe('DubbingService', () => {
     // could not cover the whole dub still got enqueued and only failed after
     // ElevenLabs had run — at which point we'd already paid for it.
     it('rejects when credits cover the floor but not the full duration', async () => {
-      await build({ profiles: chain({ data: { credits: 50 }, error: null }) });
-      await expect(service.createDub(input, USER)).rejects.toThrow(/costs 90 credits and you have 50/);
+      await build({ profiles: chain({ data: { credits: DUB_FLOOR }, error: null }) });
+      await expect(service.createDub(input, USER)).rejects.toThrow(
+        new RegExp(`costs ${DUB_COST} credits and you have ${DUB_FLOOR}`),
+      );
       expect(queue.add).not.toHaveBeenCalled();
     });
 
     // Regression: a rejected dub used to leave the uploaded media sitting in the bucket.
     it('deletes the staged upload when the dub is rejected', async () => {
-      await build({ profiles: chain({ data: { credits: 50 }, error: null }) });
+      await build({ profiles: chain({ data: { credits: DUB_FLOOR }, error: null }) });
       await expect(service.createDub(input, USER)).rejects.toThrow(ForbiddenException);
       expect(deleteGcsObject).toHaveBeenCalledWith(expect.anything(), input.objectName, 'dub-bucket');
     });
@@ -202,10 +219,10 @@ describe('DubbingService', () => {
     it('reserves the full cost before enqueueing', async () => {
       await build();
       await service.createDub(input, USER);
-      expect(rpc).toHaveBeenCalledWith('update_user_credits', { user_uuid: USER, credit_change: -90 });
+      expect(rpc).toHaveBeenCalledWith('update_user_credits', { user_uuid: USER, credit_change: -DUB_COST });
       expect(queue.add).toHaveBeenCalledWith(
         'dubbing',
-        expect.objectContaining({ reservedCredits: 90 }),
+        expect.objectContaining({ reservedCredits: DUB_COST }),
         expect.anything(),
       );
     });
@@ -213,7 +230,7 @@ describe('DubbingService', () => {
     it('refunds and cleans up when the reservation succeeds but the insert fails', async () => {
       await build({ dubbing_projects: chain({ data: null, error: { message: 'boom' } }) });
       await expect(service.createDub(input, USER)).rejects.toThrow();
-      expect(rpc).toHaveBeenCalledWith('update_user_credits', { user_uuid: USER, credit_change: 90 });
+      expect(rpc).toHaveBeenCalledWith('update_user_credits', { user_uuid: USER, credit_change: DUB_COST });
       expect(deleteGcsObject).toHaveBeenCalledWith(expect.anything(), `${USER}/dubbing/123_a.mp3`, 'dub-bucket');
       expect(queue.add).not.toHaveBeenCalled();
     });
@@ -235,7 +252,7 @@ describe('DubbingService', () => {
       expect(res.jobId).not.toContain(USER);
       expect(queue.add).toHaveBeenCalledWith(
         'dubbing',
-        expect.objectContaining({ userId: USER, targetLanguage: 'es', durationSeconds: 30 }),
+        expect.objectContaining({ userId: USER, targetLanguage: 'es', durationSeconds: DUB_SECONDS }),
         expect.objectContaining({ jobId: res.jobId }),
       );
     });
@@ -255,14 +272,14 @@ describe('DubbingService', () => {
       await build();
       const remove = jest.fn();
       queue.getJob.mockResolvedValue({
-        data: { userId: USER, projectId: 'p-1', reservedCredits: 90 },
+        data: { userId: USER, projectId: 'p-1', reservedCredits: DUB_COST },
         getState: () => Promise.resolve('waiting'),
         remove,
       });
       const res = await service.stopDub(USER, 'job-1');
       expect(remove).toHaveBeenCalled();
       // The worker never ran it, so the API owns the refund here.
-      expect(rpc).toHaveBeenCalledWith('update_user_credits', { user_uuid: USER, credit_change: 90 });
+      expect(rpc).toHaveBeenCalledWith('update_user_credits', { user_uuid: USER, credit_change: DUB_COST });
       expect(tables.dubbing_projects.update).toHaveBeenCalledWith(
         expect.objectContaining({ status: 'failed', error_message: 'Cancelled by user' }),
       );
@@ -290,7 +307,7 @@ describe('DubbingService', () => {
       target_language: 'es',
       target_accent: null,
       is_video: false,
-      duration_seconds: 30,
+      duration_seconds: DUB_SECONDS,
     };
 
     it.each(['queued', 'processing', 'cloning'])('refuses to regenerate a %s dub', async (status) => {
@@ -302,7 +319,7 @@ describe('DubbingService', () => {
     it('regenerates a completed dub, reserving credits again', async () => {
       await build({ dubbing_projects: chain({ data: { ...row, status: 'completed' }, error: null }) });
       await service.regenerateDub(USER, 'p-1');
-      expect(rpc).toHaveBeenCalledWith('update_user_credits', { user_uuid: USER, credit_change: -90 });
+      expect(rpc).toHaveBeenCalledWith('update_user_credits', { user_uuid: USER, credit_change: -DUB_COST });
       expect(queue.add).toHaveBeenCalled();
     });
 

--- a/apps/api/src/thumbnail/thumbnail.controller.ts
+++ b/apps/api/src/thumbnail/thumbnail.controller.ts
@@ -18,7 +18,12 @@ import { Queue } from 'bullmq';
 import { SupabaseAuthGuard } from '../guards/auth.guard';
 import { OnboardedGuard } from '../guards/onboarded.guard';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
-import { CreateThumbnailSchema, type CreateThumbnailInput } from '@repo/validation';
+import {
+  CreateThumbnailSchema,
+  type CreateThumbnailInput,
+  SurpriseThumbnailPromptSchema,
+  type SurpriseThumbnailPromptInput,
+} from '@repo/validation';
 import type { AuthRequest } from '../common/interfaces/auth-request.interface';
 import { getUserId } from '../common/get-user-id';
 import type { Observable } from 'rxjs';
@@ -34,6 +39,17 @@ export class ThumbnailController {
     private readonly thumbnailService: ThumbnailService,
   ) { }
 
+  @Post('surprise')
+  @UseGuards(SupabaseAuthGuard, OnboardedGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Generate an on-brand thumbnail prompt from the trained style and source content' })
+  async surprise(
+    @Body(new ZodValidationPipe(SurpriseThumbnailPromptSchema)) body: SurpriseThumbnailPromptInput,
+    @Req() req: AuthRequest,
+  ) {
+    return this.thumbnailService.surprisePrompt(getUserId(req), body);
+  }
+
   @Post('generate')
   @UseGuards(SupabaseAuthGuard, OnboardedGuard)
   @ApiBearerAuth()
@@ -43,12 +59,15 @@ export class ThumbnailController {
     required: ['prompt'],
     properties: {
       prompt: { type: 'string' },
+      context: { type: 'string' },
       ratio: { type: 'string', enum: ['16:9', '9:16', '1:1', '4:3'], default: '16:9' },
       generateCount: { type: 'integer', minimum: 1, maximum: 5, default: 3 },
       videoLink: { type: 'string', format: 'uri' },
       personalized: { type: 'boolean', default: true },
       scriptId: { type: 'string', format: 'uuid' },
       storyBuilderId: { type: 'string', format: 'uuid' },
+      ideationId: { type: 'string', format: 'uuid' },
+      ideaIndex: { type: 'integer', minimum: 0 },
       referenceImage: { type: 'string', format: 'binary' },
       faceImage: { type: 'string', format: 'binary' },
     },

--- a/apps/api/src/thumbnail/thumbnail.service.spec.ts
+++ b/apps/api/src/thumbnail/thumbnail.service.spec.ts
@@ -1,0 +1,128 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InternalServerErrorException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { getQueueToken } from '@nestjs/bullmq';
+import { ThumbnailService } from './thumbnail.service';
+import { SupabaseService } from '../supabase/supabase.service';
+import { createGoogleAI } from '../utils/genai';
+
+jest.mock('../utils/genai', () => ({
+  createGoogleAI: jest.fn(),
+  GEMINI_TEXT_MODEL: 'gemini-test',
+}));
+
+/** Chainable supabase query mock — mirrors the one in dubbing.service.spec.ts. */
+function chain(result: unknown) {
+  const c: any = {};
+  for (const m of ['select', 'eq', 'insert', 'update', 'delete', 'order', 'limit']) {
+    c[m] = jest.fn(() => c);
+  }
+  c.single = jest.fn(() => Promise.resolve(result));
+  c.maybeSingle = jest.fn(() => Promise.resolve(result));
+  c.then = (res: any, rej: any) => Promise.resolve(result).then(res, rej);
+  return c;
+}
+
+const USER = 'user-1';
+const UUID = '11111111-1111-4111-8111-111111111111';
+
+describe('ThumbnailService.surprisePrompt', () => {
+  let service: ThumbnailService;
+  let generateContent: jest.Mock;
+
+  async function build(tables: Record<string, any>, modelText = 'A bold close-up thumbnail.') {
+    jest.clearAllMocks();
+    generateContent = jest.fn().mockResolvedValue({
+      candidates: [{ content: { parts: [{ text: modelText }] } }],
+    });
+    (createGoogleAI as jest.Mock).mockResolvedValue({ models: { generateContent } });
+
+    const mockSupabase = {
+      getClient: () => ({ from: (t: string) => tables[t] ?? chain({ data: null }) }),
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ThumbnailService,
+        { provide: SupabaseService, useValue: mockSupabase },
+        { provide: ConfigService, useValue: { get: () => undefined } },
+        { provide: getQueueToken('thumbnail'), useValue: { add: jest.fn() } },
+      ],
+    }).compile();
+    service = module.get(ThumbnailService);
+  }
+
+  /** What the model was actually briefed with. */
+  const systemInstruction = () => generateContent.mock.calls[0][0].config.systemInstruction as string;
+
+  it('briefs the model with the linked script', async () => {
+    await build({
+      user_style: chain({ data: { tone: 'dry', visual_style: 'high contrast' } }),
+      scripts: chain({ data: { title: 'Ship faster', content: 'Step one: delete code.' } }),
+    });
+
+    await expect(service.surprisePrompt(USER, { scriptId: UUID })).resolves.toMatchObject({
+      prompt: 'A bold close-up thumbnail.',
+    });
+    expect(systemInstruction()).toContain('Script Title: Ship faster');
+    expect(systemInstruction()).toContain('Step one: delete code.');
+    expect(systemInstruction()).toContain('Visual style: high contrast');
+  });
+
+  it('briefs the model with the story blueprint hook, not just the topic', async () => {
+    await build({
+      user_style: chain({ data: null }),
+      story_builder_jobs: chain({
+        data: {
+          video_topic: 'Why builds break',
+          result: {
+            structuredBlueprint: {
+              hook: { openingLine: 'Your build is lying', visualSuggestion: 'red terminal glow' },
+              climax: { biggestInsight: 'the cache was stale' },
+            },
+          },
+        },
+      }),
+    });
+
+    await service.surprisePrompt(USER, { storyBuilderId: UUID });
+    expect(systemInstruction()).toContain('Story Topic: Why builds break');
+    expect(systemInstruction()).toContain('Suggested Visual: red terminal glow');
+    expect(systemInstruction()).toContain('Biggest Insight: the cache was stale');
+  });
+
+  it('briefs the model with the chosen idea, addressed by index', async () => {
+    await build({
+      user_style: chain({ data: null }),
+      ideation_jobs: chain({
+        data: {
+          result: {
+            ideas: [
+              { title: 'Wrong one' },
+              { title: 'Right one', uniqueAngle: 'nobody measures this' },
+            ],
+          },
+        },
+      }),
+    });
+
+    await service.surprisePrompt(USER, { ideationId: UUID, ideaIndex: 1 });
+    expect(systemInstruction()).toContain('Title: Right one');
+    expect(systemInstruction()).toContain('Unique Angle: nobody measures this');
+    expect(systemInstruction()).not.toContain('Wrong one');
+  });
+
+  it('falls back to the typed context when there is no source', async () => {
+    await build({ user_style: chain({ data: null }) });
+
+    await service.surprisePrompt(USER, { context: 'Video: my morning routine' });
+    expect(systemInstruction()).toContain('Video: my morning routine');
+  });
+
+  it('fails loudly when the model returns nothing', async () => {
+    await build({ user_style: chain({ data: null }) }, '');
+
+    await expect(service.surprisePrompt(USER, {})).rejects.toBeInstanceOf(
+      InternalServerErrorException,
+    );
+  });
+});

--- a/apps/api/src/thumbnail/thumbnail.service.ts
+++ b/apps/api/src/thumbnail/thumbnail.service.ts
@@ -6,15 +6,18 @@ import {
   BadRequestException,
   Logger,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
 import { SupabaseService } from '../supabase/supabase.service';
 import {
   type CreateThumbnailInput,
+  type SurpriseThumbnailPromptInput,
   hasEnoughCredits,
   THUMBNAIL_CREDIT_MULTIPLIER,
   getMinimumCreditsForThumbnailRequest,
 } from '@repo/validation';
+import { createGoogleAI, GEMINI_TEXT_MODEL } from '../utils/genai';
 
 const BUCKET = 'thumbnails';
 const MAX_IMAGE_SIZE = 10 * 1024 * 1024;
@@ -26,6 +29,7 @@ export class ThumbnailService {
 
   constructor(
     private readonly supabaseService: SupabaseService,
+    private readonly configService: ConfigService,
     @InjectQueue('thumbnail') private readonly queue: Queue,
   ) {}
 
@@ -35,7 +39,7 @@ export class ThumbnailService {
     referenceImage?: Express.Multer.File,
     faceImage?: Express.Multer.File,
   ) {
-    const { prompt, ratio, generateCount, videoLink, personalized, scriptId, storyBuilderId } = input;
+    const { prompt, context, ratio, generateCount, videoLink, personalized } = input;
 
     if (referenceImage) this.validateImageFile(referenceImage, 'Reference image');
     if (faceImage) this.validateImageFile(faceImage, 'Face image');
@@ -84,32 +88,7 @@ export class ThumbnailService {
       );
     }
 
-    let contentContext: string | undefined;
-    if (scriptId) {
-      const { data: script } = await this.supabaseService
-        .getClient()
-        .from('scripts')
-        .select('title, content')
-        .eq('id', scriptId)
-        .eq('user_id', userId)
-        .single();
-
-      if (script) {
-        contentContext = `Script Title: ${script.title}\n${(script.content || '').slice(0, 500)}`;
-      }
-    } else if (storyBuilderId) {
-      const { data: story } = await this.supabaseService
-        .getClient()
-        .from('story_builder_jobs')
-        .select('video_topic, result')
-        .eq('id', storyBuilderId)
-        .eq('user_id', userId)
-        .single();
-
-      if (story) {
-        contentContext = `Story Topic: ${story.video_topic}`;
-      }
-    }
+    const contentContext = await this.resolveSourceContext(userId, input);
 
     const shouldPersonalize = personalized && profile.ai_trained;
 
@@ -130,8 +109,8 @@ export class ThumbnailService {
         error_message: null,
         credits_consumed: 0,
         job_id: bullJobId,
-        script_id: scriptId || null,
-        story_builder_id: storyBuilderId || null,
+        script_id: input.scriptId || null,
+        story_builder_id: input.storyBuilderId || null,
       })
       .select('id')
       .single();
@@ -158,6 +137,7 @@ export class ThumbnailService {
         videoLink: videoLink || null,
         personalized: shouldPersonalize,
         contentContext,
+        userContext: context || undefined,
       },
       {
         jobId: bullJobId,
@@ -248,6 +228,148 @@ export class ThumbnailService {
 
     if (error) throw new InternalServerErrorException('Failed to delete thumbnail job');
     return { success: true, message: 'Thumbnail job deleted' };
+  }
+
+  /**
+   * "Surprise me": one on-brand thumbnail prompt built from the creator's trained
+   * style plus whatever they arrived with (a script, a blueprint, an idea, or free
+   * text). Ungated on purpose — it is cheap and it is how a locked user sees the
+   * feature work before the paywall on Generate.
+   */
+  async surprisePrompt(userId: string, input: SurpriseThumbnailPromptInput) {
+    const [{ data: style }, sourceContext] = await Promise.all([
+      this.supabaseService
+        .getClient()
+        .from('user_style')
+        .select('tone, visual_style, themes, humor_style, narrative_structure')
+        .eq('user_id', userId)
+        .maybeSingle(),
+      this.resolveSourceContext(userId, input),
+    ]);
+
+    const styleLines = style
+      ? [
+          style.tone && `Tone: ${style.tone}`,
+          style.visual_style && `Visual style: ${style.visual_style}`,
+          style.themes && `Themes: ${style.themes}`,
+          style.humor_style && `Humor: ${style.humor_style}`,
+          style.narrative_structure && `Narrative structure: ${style.narrative_structure}`,
+        ]
+          .filter(Boolean)
+          .join('\n')
+      : '';
+
+    const brief = [sourceContext, input.context?.trim()].filter(Boolean).join('\n\n');
+
+    const system = [
+      'You write a single image-generation prompt for a YouTube thumbnail.',
+      'Return ONLY the prompt text — no preamble, no quotes, no markdown, no options list.',
+      'Describe the subject, composition, colors, lighting, mood, and the short text overlay (4 words max, in quotes). Two or three sentences, under 70 words.',
+      'It must read as a click-worthy thumbnail, not a stock photo: high contrast, one clear focal point, room for the text overlay.',
+      brief
+        ? `Base it on the video this thumbnail is for:\n${brief}`
+        : 'The creator has not described a video yet, so invent a broadly appealing, visually striking concept.',
+      styleLines
+        ? `Align it with this creator's established style:\n${styleLines}`
+        : 'The creator has no saved style yet, so keep it broadly appealing.',
+    ].join('\n\n');
+
+    try {
+      const ai = await createGoogleAI(this.configService);
+      const result = await ai.models.generateContent({
+        model: GEMINI_TEXT_MODEL,
+        contents: [{ role: 'user', parts: [{ text: 'Give me one fresh thumbnail prompt.' }] }],
+        // thinkingLevel minimal: Gemini 3 otherwise spends the whole maxOutputTokens
+        // budget on thoughts and returns a truncated fragment. A one-line prompt needs none.
+        config: {
+          systemInstruction: system,
+          temperature: 1.1,
+          maxOutputTokens: 250,
+          thinkingConfig: { thinkingLevel: 'minimal' },
+        } as any,
+      });
+      const prompt = (
+        (result as any)?.candidates?.[0]?.content?.parts?.[0]?.text ??
+        result?.text ??
+        ''
+      )
+        .trim()
+        .replace(/^["']|["']$/g, '');
+      if (!prompt) throw new Error('empty');
+      return { success: true, prompt };
+    } catch (e) {
+      this.logger.error(`Surprise thumbnail prompt failed for user ${userId}: ${(e as Error).message}`);
+      throw new InternalServerErrorException('Could not generate a prompt right now. Please try again.');
+    }
+  }
+
+  /**
+   * Turn whichever source the creator came from into plain-text context the model
+   * can use. Shared by createJob (passed to the worker) and surprisePrompt.
+   */
+  private async resolveSourceContext(
+    userId: string,
+    { scriptId, storyBuilderId, ideationId, ideaIndex }: SurpriseThumbnailPromptInput,
+  ): Promise<string | undefined> {
+    if (scriptId) {
+      const { data: script } = await this.supabaseService
+        .getClient()
+        .from('scripts')
+        .select('title, content')
+        .eq('id', scriptId)
+        .eq('user_id', userId)
+        .single();
+
+      if (script) return `Script Title: ${script.title}\n${(script.content || '').slice(0, 500)}`;
+      return undefined;
+    }
+
+    if (storyBuilderId) {
+      const { data: story } = await this.supabaseService
+        .getClient()
+        .from('story_builder_jobs')
+        .select('video_topic, result')
+        .eq('id', storyBuilderId)
+        .eq('user_id', userId)
+        .single();
+
+      if (!story) return undefined;
+      const hook = story.result?.structuredBlueprint?.hook;
+      return [
+        `Story Topic: ${story.video_topic}`,
+        hook?.openingLine && `Opening Line: ${hook.openingLine}`,
+        hook?.curiosityStatement && `Curiosity Statement: ${hook.curiosityStatement}`,
+        hook?.visualSuggestion && `Suggested Visual: ${hook.visualSuggestion}`,
+        story.result?.structuredBlueprint?.climax?.biggestInsight &&
+          `Biggest Insight: ${story.result.structuredBlueprint.climax.biggestInsight}`,
+      ]
+        .filter(Boolean)
+        .join('\n');
+    }
+
+    if (ideationId && ideaIndex != null) {
+      const { data: ideationJob } = await this.supabaseService
+        .getClient()
+        .from('ideation_jobs')
+        .select('result')
+        .eq('id', ideationId)
+        .eq('user_id', userId)
+        .single();
+
+      const idea = ideationJob?.result?.ideas?.[ideaIndex];
+      if (!idea) return undefined;
+      return [
+        `Title: ${idea.title}`,
+        idea.coreTopic && `Core Topic: ${idea.coreTopic}`,
+        idea.uniqueAngle && `Unique Angle: ${idea.uniqueAngle}`,
+        idea.hookAngle && `Hook Angle: ${idea.hookAngle}`,
+        idea.suggestedFormat && `Suggested Format: ${idea.suggestedFormat}`,
+      ]
+        .filter(Boolean)
+        .join('\n');
+    }
+
+    return undefined;
   }
 
   // ─── Helpers ───

--- a/apps/web/app/dashboard/scripts/[id]/page.tsx
+++ b/apps/web/app/dashboard/scripts/[id]/page.tsx
@@ -163,7 +163,7 @@ export default function ScriptPage() {
               <span>{script.credits_consumed} credit{script.credits_consumed > 1 ? "s" : ""} used</span>
             </div>
           )}
-          <Link href={`/dashboard/thumbnails/new?scriptId=${scriptId}&prompt=${encodeURIComponent(title || "")}`}>
+          <Link href={`/dashboard/thumbnails/new?scriptId=${scriptId}&title=${encodeURIComponent(title || "")}`}>
             <Button variant="outline" size="sm">
               <ImageIcon className="h-4 w-4 mr-2" />
               Generate Thumbnail

--- a/apps/web/app/dashboard/story-builder/[id]/page.tsx
+++ b/apps/web/app/dashboard/story-builder/[id]/page.tsx
@@ -110,7 +110,7 @@ export default function StoryBuilderDetailPage() {
                                 </p>
                             </div>
                             <div className="flex gap-2 shrink-0">
-                                <Link href={`/dashboard/thumbnails/new?storyBuilderId=${jobId}&prompt=${encodeURIComponent(job.video_topic || "")}`}>
+                                <Link href={`/dashboard/thumbnails/new?storyBuilderId=${jobId}&title=${encodeURIComponent(job.video_topic || "")}`}>
                                     <Button variant="outline" size="sm" className="gap-1.5">
                                         <ImageIcon className="h-3.5 w-3.5" />
                                         Thumbnail

--- a/apps/web/app/dashboard/thumbnails/new/page.tsx
+++ b/apps/web/app/dashboard/thumbnails/new/page.tsx
@@ -12,7 +12,7 @@ import { VideoFrameModal } from "@/components/dashboard/thumbnails/VideoFrameMod
 import { useAISetupGate } from "@/hooks/useAISetupGate";
 import { Skeleton } from "@repo/ui/skeleton";
 import { Badge } from "@repo/ui/badge";
-import { FileText, Clapperboard } from "lucide-react"
+import { FileText, Clapperboard, Sparkles } from "lucide-react"
 
 function NewThumbnailPageInner() {
   const router = useRouter()
@@ -22,6 +22,12 @@ function NewThumbnailPageInner() {
 
   const scriptId = searchParams.get("scriptId") ?? undefined
   const storyBuilderId = searchParams.get("storyBuilderId") ?? undefined
+  const ideationId = searchParams.get("ideationId") ?? undefined
+  const ideaIndexParam = searchParams.get("ideaIndex")
+  const ideaIndex = ideaIndexParam != null ? Number(ideaIndexParam) : undefined
+  // `title` is what the source feature is called (script title, video topic, idea).
+  // `prompt` stays supported for older links that put the title straight in the prompt.
+  const sourceTitle = searchParams.get("title") ?? undefined
   const initialPrompt = searchParams.get("prompt") ?? undefined
 
   const {
@@ -34,17 +40,21 @@ function NewThumbnailPageInner() {
     isGenerating, progress, statusMessage,
     generatedImages, creditsConsumed,
     showOutput,
-    handleGenerate, handleRegenerate,
-    handleDownload, handleUsePreset, clearForm,
+    handleGenerate, handleRegenerate, surpriseMe,
+    handleDownload, clearForm,
+    isSurprising, isTyping,
   } = useThumbnailGeneration({
     onComplete: (id) => router.push(`/dashboard/thumbnails/${id}`),
     initialPrompt,
+    initialContext: sourceTitle ? `Video: ${sourceTitle}` : undefined,
     initialScriptId: scriptId,
     initialStoryBuilderId: storyBuilderId,
+    initialIdeationId: ideationId,
+    initialIdeaIndex: ideaIndex,
   })
 
-  const sourceLabel = scriptId ? "Script" : storyBuilderId ? "Story Builder" : null
-  const SourceIcon = scriptId ? FileText : Clapperboard
+  const sourceLabel = scriptId ? "Script" : storyBuilderId ? "Story Builder" : ideationId ? "Ideation" : null
+  const SourceIcon = scriptId ? FileText : storyBuilderId ? Clapperboard : Sparkles
 
   const [showFrameModal, setShowFrameModal] = useState(false)
 
@@ -75,7 +85,11 @@ function NewThumbnailPageInner() {
             <Badge variant="secondary" className="bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300">
               <SourceIcon className="h-3 w-3 mr-1" /> From {sourceLabel}
             </Badge>
-            {initialPrompt && <span className="text-sm text-slate-600 dark:text-slate-400 truncate max-w-md">{initialPrompt}</span>}
+            {(sourceTitle ?? initialPrompt) && (
+              <span className="text-sm text-slate-600 dark:text-slate-400 truncate max-w-md">
+                {sourceTitle ?? initialPrompt}
+              </span>
+            )}
           </div>
         )}
       </div>
@@ -125,9 +139,11 @@ function NewThumbnailPageInner() {
                   faceImage={faceImage}
                   setFaceImage={setFaceImage}
                   isGenerating={isGenerating}
+                  isSurprising={isSurprising}
+                  isTyping={isTyping}
                   onGenerate={gate.locked ? gate.requestUnlock : handleGenerate}
+                  onSurpriseMe={surpriseMe}
                   locked={gate.locked}
-                  onUsePreset={handleUsePreset}
                 />
               </motion.div>
             )}

--- a/apps/web/components/dashboard/research/IdeaCard.tsx
+++ b/apps/web/components/dashboard/research/IdeaCard.tsx
@@ -170,7 +170,7 @@ export default function IdeaCard({ idea, index, ideationId }: IdeaCardProps) {
             <Button
               size="sm" variant="outline"
               className="text-xs sm:text-sm h-8 sm:h-9"
-              onClick={() => router.push(`/dashboard/thumbnails/new?prompt=${encodeURIComponent(idea.title)}`)}
+              onClick={() => router.push(`/dashboard/thumbnails/new?ideationId=${ideationId}&ideaIndex=${index}&title=${encodeURIComponent(idea.title)}`)}
             >
               <ImageIcon className="h-3 w-3 sm:h-3.5 sm:w-3.5 mr-1 sm:mr-1.5" /> Thumbnail
             </Button>

--- a/apps/web/components/dashboard/thumbnails/ThumbnailForm.tsx
+++ b/apps/web/components/dashboard/thumbnails/ThumbnailForm.tsx
@@ -31,8 +31,10 @@ interface ThumbnailFormProps {
   faceImage: File | null
   setFaceImage: (v: File | null) => void
   isGenerating: boolean
+  isSurprising: boolean
+  isTyping: boolean
   onGenerate: () => void
-  onUsePreset: (prompt: string) => void
+  onSurpriseMe: () => void
   locked?: boolean
 }
 
@@ -43,8 +45,8 @@ export function ThumbnailForm({
   videoLink, setVideoLink,
   referenceImage, setReferenceImage,
   faceImage, setFaceImage,
-  isGenerating,
-  onGenerate, onUsePreset,
+  isGenerating, isSurprising, isTyping,
+  onGenerate, onSurpriseMe,
   locked,
 }: ThumbnailFormProps) {
   const [step, setStep] = useState(1)
@@ -100,7 +102,10 @@ export function ThumbnailForm({
                 context={context}
                 setContext={setContext}
                 promptError={promptError}
-                onUsePreset={onUsePreset}
+                onSurpriseMe={onSurpriseMe}
+                isSurprising={isSurprising}
+                isTyping={isTyping}
+                isGenerating={isGenerating}
               />
             )}
             {step === 2 && (

--- a/apps/web/components/dashboard/thumbnails/ThumbnailStep1.tsx
+++ b/apps/web/components/dashboard/thumbnails/ThumbnailStep1.tsx
@@ -2,28 +2,9 @@
 
 import { Label } from "@repo/ui/label"
 import { Textarea } from "@repo/ui/textarea"
-
-
-/**
- * @todo later on we'll fetch and show popular prompt examples from other user from DB
- */
-const PRESET_PROMPTS = [
-  {
-    label: "Tech Tutorial",
-    prompt:
-      "Eye-catching tech tutorial thumbnail with a laptop screen showing code, neon blue accents, bold title text overlay, dark gradient background",
-  },
-  {
-    label: "Travel Vlog",
-    prompt:
-      "Stunning travel vlog thumbnail with a beautiful landscape, warm sunset tones, person looking at a scenic view, adventure vibes with bold text",
-  },
-  {
-    label: "Cooking / Food",
-    prompt:
-      "Appetizing food thumbnail with a delicious dish in the center, steam rising, vibrant colors, rustic wooden table background, bold recipe title",
-  },
-]
+import * as motion from "motion/react-m"
+import { Loader2, Wand2 } from "lucide-react"
+import { cn } from "@repo/ui/lib/utils"
 
 interface ThumbnailStep1Props {
   prompt: string
@@ -31,7 +12,10 @@ interface ThumbnailStep1Props {
   context: string
   setContext: (v: string) => void
   promptError: string | null
-  onUsePreset: (prompt: string) => void
+  onSurpriseMe: () => void
+  isSurprising: boolean
+  isTyping: boolean
+  isGenerating: boolean
 }
 
 export default function ThumbnailStep1({
@@ -40,43 +24,58 @@ export default function ThumbnailStep1({
   context,
   setContext,
   promptError,
-  onUsePreset,
+  onSurpriseMe,
+  isSurprising,
+  isTyping,
+  isGenerating,
 }: ThumbnailStep1Props) {
   return (
     <div className="space-y-4">
       <h3 className="text-xl font-semibold">Step 1: Describe your thumbnail</h3>
 
       <div className="space-y-2">
-        <Label>Popular Templates</Label>
-        <div className="flex flex-col gap-2">
-          {PRESET_PROMPTS.map((p) => (
-            <button
-              key={p.label}
-              type="button"
-              onClick={() => onUsePreset(p.prompt)}
-              className="text-left rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 px-4 py-3 text-sm text-slate-700 dark:text-slate-300 hover:border-purple-400 dark:hover:border-purple-500 hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-colors"
-            >
-              <span className="font-medium text-slate-900 dark:text-slate-100">{p.label}</span>
-              <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400 line-clamp-2">{p.prompt}</p>
-            </button>
-          ))}
+        <div className="flex items-center justify-between gap-2">
+          <Label htmlFor="prompt">
+            Thumbnail Prompt <span className="text-red-500">*</span>
+          </Label>
+          {/* Surprise me — on-brand prompt from the creator's trained style and source content. */}
+          <motion.button
+            type="button"
+            onClick={onSurpriseMe}
+            disabled={isSurprising || isTyping || isGenerating}
+            whileHover={{ scale: 1.04 }}
+            whileTap={{ scale: 0.96 }}
+            className="group relative inline-flex items-center gap-1.5 rounded-full bg-gradient-to-r from-purple-600 to-indigo-600 px-3 py-1.5 text-xs font-medium text-white shadow-sm disabled:opacity-60"
+          >
+            <span className="absolute inset-0 rounded-full bg-white/20 opacity-0 group-hover:opacity-100 blur-sm transition-opacity" />
+            {isSurprising ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <motion.span
+                animate={{ rotate: [0, -12, 12, 0] }}
+                transition={{ repeat: Infinity, repeatDelay: 2.5, duration: 0.8 }}
+              >
+                <Wand2 className="h-3.5 w-3.5" />
+              </motion.span>
+            )}
+            Surprise me
+          </motion.button>
         </div>
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="prompt">
-          Thumbnail Prompt <span className="text-red-500">*</span>
-        </Label>
         <Textarea
           id="prompt"
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
+          disabled={isTyping}
           placeholder="e.g., A dramatic thumbnail showing a person reacting to a computer screen with bold red and blue gradient, text overlay saying 'SHOCKING RESULTS'"
-          className="min-h-[120px] focus-visible:ring-purple-500"
+          className={cn(
+            "min-h-[120px] focus-visible:ring-purple-500",
+            isTyping && "ring-1 ring-purple-400/60 transition-shadow",
+          )}
         />
         {promptError && <p className="text-red-500 text-sm">{promptError}</p>}
         <p className="text-xs text-muted-foreground">
-          Be specific about colors, composition, text overlays, and mood
+          Be specific about colors, composition, text overlays, and mood — or let Surprise me
+          draft one in your channel style.
         </p>
       </div>
 
@@ -89,6 +88,9 @@ export default function ThumbnailStep1({
           placeholder="e.g., The video is about productivity tips for developers. My channel has a dark/techy aesthetic."
           className="min-h-[100px] focus-visible:ring-purple-500"
         />
+        <p className="text-xs text-muted-foreground">
+          What the video is about. Used by Surprise me and by the generator.
+        </p>
       </div>
     </div>
   )

--- a/apps/web/hooks/useThumbnailGeneration.ts
+++ b/apps/web/hooks/useThumbnailGeneration.ts
@@ -1,11 +1,12 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
 import { toast } from "sonner"
 import { useSupabase } from "@/components/supabase-provider"
 import { api, getApiErrorMessage } from "@/lib/api-client"
 import { downloadFile } from "@/lib/download"
 import { useSSE, type SSEEvent } from "./useSSE"
+import { useTypewriter } from "./useTypewriter"
 
 export type ThumbnailRatio = '16:9' | '9:16' | '1:1' | '4:3'
 
@@ -38,8 +39,11 @@ interface GenerateResponse {
 interface UseThumbnailGenerationOptions {
   onComplete?: (thumbnailJobId: string) => void
   initialPrompt?: string
+  initialContext?: string
   initialScriptId?: string
   initialStoryBuilderId?: string
+  initialIdeationId?: string
+  initialIdeaIndex?: number
 }
 
 const STATUS_MESSAGES: Record<string, (p: number) => string> = {
@@ -54,16 +58,19 @@ export function useThumbnailGeneration(options?: UseThumbnailGenerationOptions) 
   const { profile } = useSupabase()
 
   const [prompt, setPrompt] = useState(options?.initialPrompt ?? "")
-  const [context, setContext] = useState("")
+  const [context, setContext] = useState(options?.initialContext ?? "")
   const [ratio, setRatio] = useState<ThumbnailRatio>("16:9")
   const [scriptId] = useState(options?.initialScriptId)
   const [storyBuilderId] = useState(options?.initialStoryBuilderId)
+  const [ideationId] = useState(options?.initialIdeationId)
+  const [ideaIndex] = useState(options?.initialIdeaIndex)
   const [generateCount] = useState(3)
   const [videoLink, setVideoLink] = useState("")
   const [referenceImage, setReferenceImage] = useState<File | null>(null)
   const [faceImage, setFaceImage] = useState<File | null>(null)
 
   const [isGenerating, setIsGenerating] = useState(false)
+  const [isSurprising, setIsSurprising] = useState(false)
   const [jobId, setJobId] = useState<string | null>(null)
   const [thumbnailJobId, setThumbnailJobId] = useState<string | null>(null)
 
@@ -142,8 +149,11 @@ export function useThumbnailGeneration(options?: UseThumbnailGenerationOptions) 
       if (videoLink.trim()) formData.append('videoLink', videoLink.trim())
       if (referenceImage) formData.append('referenceImage', referenceImage)
       if (faceImage) formData.append('faceImage', faceImage)
+      if (context.trim()) formData.append('context', context.trim())
       if (scriptId) formData.append('scriptId', scriptId)
       if (storyBuilderId) formData.append('storyBuilderId', storyBuilderId)
+      if (ideationId) formData.append('ideationId', ideationId)
+      if (ideaIndex != null) formData.append('ideaIndex', String(ideaIndex))
 
       const response = await api.upload<GenerateResponse>(
         '/api/v1/thumbnail/generate',
@@ -177,7 +187,43 @@ export function useThumbnailGeneration(options?: UseThumbnailGenerationOptions) 
     [],
   )
 
-  const handleUsePreset = (presetPrompt: string) => setPrompt(presetPrompt)
+  const { typeOut, isTyping } = useTypewriter(setPrompt)
+
+  /** Ask the API for an on-brand prompt seeded by the source this page was opened from. */
+  const surpriseMe = async () => {
+    setIsSurprising(true)
+    try {
+      const res = await api.post<{ success: boolean; prompt: string }>(
+        '/api/v1/thumbnail/surprise',
+        {
+          context: context.trim() || undefined,
+          scriptId,
+          storyBuilderId,
+          ideationId,
+          ideaIndex,
+        },
+        { requireAuth: true },
+      )
+      if (res.prompt) typeOut(res.prompt)
+    } catch (error) {
+      toast.error("Couldn't dream one up", {
+        description: getApiErrorMessage(error, "Please try again."),
+      })
+    } finally {
+      setIsSurprising(false)
+    }
+  }
+
+  // Landed here from a script, blueprint or idea with nothing typed yet: draft the
+  // prompt from that source once, so the form arrives filled instead of blank.
+  const autoDrafted = useRef(false)
+  useEffect(() => {
+    if (autoDrafted.current) return
+    if (!scriptId && !storyBuilderId && ideationId == null) return
+    if (prompt.trim()) return
+    autoDrafted.current = true
+    surpriseMe()
+  }, [scriptId, storyBuilderId, ideationId])
 
   const clearForm = () => {
     setPrompt("")
@@ -199,12 +245,12 @@ export function useThumbnailGeneration(options?: UseThumbnailGenerationOptions) 
     videoLink, setVideoLink,
     referenceImage, setReferenceImage,
     faceImage, setFaceImage,
-    isGenerating,
+    isGenerating, isSurprising, isTyping,
     progress: sse.progress, statusMessage: sse.statusMessage,
     generatedImages, creditsConsumed,
     showOutput,
     pastJobs, isLoadingJobs,
-    handleGenerate, handleRegenerate,
-    handleDownload, handleUsePreset, clearForm,
+    handleGenerate, handleRegenerate, surpriseMe,
+    handleDownload, clearForm,
   }
 }

--- a/apps/web/hooks/useTypewriter.ts
+++ b/apps/web/hooks/useTypewriter.ts
@@ -1,0 +1,33 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+/**
+ * Reveal AI-generated text letter-by-letter into a controlled field, so a
+ * "Surprise me" result lands as visible writing rather than a sudden paste.
+ */
+export function useTypewriter(setText: (v: string) => void, speedMs = 22) {
+  const [isTyping, setIsTyping] = useState(false)
+  const timer = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const typeOut = (text: string) => {
+    if (timer.current) clearInterval(timer.current)
+    setIsTyping(true)
+    setText("")
+    let i = 0
+    timer.current = setInterval(() => {
+      i += 1
+      setText(text.slice(0, i))
+      if (i >= text.length) {
+        if (timer.current) clearInterval(timer.current)
+        timer.current = null
+        setIsTyping(false)
+      }
+    }, speedMs)
+  }
+
+  // Stop the animation if the component unmounts mid-type.
+  useEffect(() => () => { if (timer.current) clearInterval(timer.current) }, [])
+
+  return { typeOut, isTyping }
+}

--- a/apps/web/hooks/useVideoGeneration.ts
+++ b/apps/web/hooks/useVideoGeneration.ts
@@ -1,9 +1,10 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect } from "react"
 import { toast } from "sonner"
 import { api, getApiErrorMessage } from "@/lib/api-client"
 import { useSSE, type SSEEvent } from "./useSSE"
+import { useTypewriter } from "./useTypewriter"
 import {
   type VideoAspectRatio,
   type VideoDurationSeconds,
@@ -69,8 +70,6 @@ export function useVideoGeneration() {
 
   const [isGenerating, setIsGenerating] = useState(false)
   const [isSurprising, setIsSurprising] = useState(false)
-  const [isTyping, setIsTyping] = useState(false)
-  const typeTimer = useRef<ReturnType<typeof setInterval> | null>(null)
   const [jobId, setJobId] = useState<string | null>(null)
   const [videoJobId, setVideoJobId] = useState<string | null>(null)
   const [videoUrl, setVideoUrl] = useState<string | null>(null)
@@ -118,25 +117,7 @@ export function useVideoGeneration() {
     },
   })
 
-  // Reveal the generated prompt letter-by-letter for a subtle "typing" effect.
-  const typeOut = (text: string) => {
-    if (typeTimer.current) clearInterval(typeTimer.current)
-    setIsTyping(true)
-    setPrompt("")
-    let i = 0
-    typeTimer.current = setInterval(() => {
-      i += 1
-      setPrompt(text.slice(0, i))
-      if (i >= text.length) {
-        if (typeTimer.current) clearInterval(typeTimer.current)
-        typeTimer.current = null
-        setIsTyping(false)
-      }
-    }, 22)
-  }
-
-  // Stop the animation if the component unmounts mid-type.
-  useEffect(() => () => { if (typeTimer.current) clearInterval(typeTimer.current) }, [])
+  const { typeOut, isTyping } = useTypewriter(setPrompt)
 
   const surpriseMe = async () => {
     setIsSurprising(true)

--- a/apps/web/lib/content-shapes.ts
+++ b/apps/web/lib/content-shapes.ts
@@ -1,0 +1,34 @@
+/**
+ * Content shapes shared by the /tools pages and the /features pages.
+ *
+ * These started life in lib/free-tools.ts as ToolStep/ToolSection/ToolFaq. The
+ * product feature registry needs the same three shapes for its landing pages,
+ * and importing them out of the free-tools registry would make the list of what
+ * the product does depend on the list of free marketing tools, which is
+ * backwards. They live here instead; free-tools.ts re-exports the original
+ * names as aliases, so nothing that already imported them had to change.
+ *
+ * Data only, no React: scripts/generate-llms.mts imports the registries from
+ * plain node, which resolves neither the "@/" alias nor JSX.
+ */
+
+/** One numbered step in a "how it works" list. */
+export interface ContentStep {
+  title: string;
+  description: string;
+}
+
+/**
+ * One long-form body section. `body` holds one entry per paragraph and may use
+ * `**bold**`, `*italic*` and `[label](/href)` — the only inline formatting the
+ * RichText parser in components/tools/ToolPageShell.tsx understands.
+ */
+export interface ContentSection {
+  heading: string;
+  body: string[];
+}
+
+export interface ContentFaq {
+  question: string;
+  answer: string;
+}

--- a/apps/web/lib/free-tools.ts
+++ b/apps/web/lib/free-tools.ts
@@ -1,5 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 import { Compass, Gauge, Layers, Mic, Timer, Wand2 } from "lucide-react";
+import type { ContentFaq, ContentSection, ContentStep } from "./content-shapes";
 
 /**
  * The public, no-signup tools at /tools.
@@ -20,20 +21,12 @@ import { Compass, Gauge, Layers, Mic, Timer, Wand2 } from "lucide-react";
  * cannibalize each other (see .claude/skills/blog-post-seo, STEP 0).
  */
 
-export interface ToolStep {
-  title: string;
-  description: string;
-}
-
-export interface ToolSection {
-  heading: string;
-  body: string[];
-}
-
-export interface ToolFaq {
-  question: string;
-  answer: string;
-}
+// Shared with the /features landing pages, so the shapes live in one neutral
+// module. The Tool* names stay as aliases: every existing import of them keeps
+// working, and a tool page still reads as if it owns its own types.
+export type ToolStep = ContentStep;
+export type ToolSection = ContentSection;
+export type ToolFaq = ContentFaq;
 
 /** The three benefit cards directly under the tool, before the long-form body. */
 export interface ToolBenefit {

--- a/apps/web/lib/product-features.ts
+++ b/apps/web/lib/product-features.ts
@@ -12,6 +12,7 @@ import {
   Languages,
   Film,
 } from "lucide-react";
+import type { ContentFaq, ContentSection, ContentStep } from "./content-shapes";
 
 /**
  * The canonical list of what Creator AI ships.
@@ -24,7 +25,45 @@ import {
  *
  * `id` doubles as the /features anchor, so nav dropdown links like
  * /features#dubbing resolve to a real section.
+ *
+ * It is also the /features/<slug> segment. `id` is the ONE identifier: the hub
+ * anchor and the detail page are the same string, so the two can never point at
+ * different features. Do not add a parallel `slug` field.
+ *
+ * Every core feature also carries the copy its detail page renders. That copy
+ * targets PRODUCT intent ("ai script writing for youtube"), while the free
+ * tools in lib/free-tools.ts own the TRANSACTIONAL version of the same topic
+ * ("youtube script generator") and the blog owns the informational version. All
+ * three chasing one phrase would cannibalize each other, so a new focusKeyword
+ * here has to be checked against both of those files first.
  */
+
+/**
+ * The ~1 minute product demo at the top of a feature page.
+ *
+ * Video files are NOT committed: there are no .mp4s in apps/web/public and
+ * there should not be, so `mp4`/`webm` are public bucket URLs. The poster is
+ * small enough to live in public/.
+ *
+ * Note that a self-hosted file needs a `media-src` on the CSP in
+ * next.config.mjs, which currently has no such directive and so falls back to
+ * `default-src 'self'`.
+ */
+export interface FeatureDemoVideo {
+  /** H.264 MP4, public URL. */
+  mp4: string;
+  /** WebM sibling of the same recording, offered first via <source>. */
+  webm?: string;
+  /** Poster frame, served from public/ so nothing shifts before playback. */
+  poster: string;
+  /** WebVTT track. Required, not optional: captions are an accessibility need. */
+  captions: string;
+  /** Runtime in seconds. VideoObject.duration (PT58S) is derived from this. */
+  durationSeconds: number;
+  /** Plain-text transcript rendered on the page, one entry per paragraph. This
+   *  is the part search and answer engines actually index. */
+  transcript: string[];
+}
 
 export interface ProductFeature {
   id: string;
@@ -37,6 +76,36 @@ export interface ProductFeature {
   highlights: string[];
   icon: LucideIcon;
   gradient: string;
+
+  // -- /features/<slug> detail page ------------------------------------------
+  // Required, so a feature cannot be added to CORE_FEATURES without the copy its
+  // page needs. The two SimpleFeature lists below get no page and no fields.
+
+  /** <title> and OG title. Distinct from `title`, the short nav/card label. */
+  seoTitle: string;
+  /** Meta description, under 155 chars — the ceiling the blog and /tools use. */
+  seoDescription: string;
+  /** The ONE product-intent phrase this page ranks for. Read the note on
+   *  cannibalization at the top of this file before adding another. */
+  focusKeyword: string;
+  /** Supporting long-tail terms. */
+  keywords: string[];
+  /** Page H1. Carries the focus keyword. */
+  h1: string;
+  /** Lead paragraph. AEO: answers the query in its first sentence. */
+  answerSummary: string;
+  /** How it works. */
+  steps: ContentStep[];
+  /** Long-form body, the part that earns the ranking. */
+  sections: ContentSection[];
+  faqs: ContentFaq[];
+  /** Undefined until the recording exists. The page must render without it. */
+  demoVideo?: FeatureDemoVideo;
+  /** Other CORE_FEATURES ids, rendered as internal links. */
+  relatedFeatures?: string[];
+  /** Blog posts by slug. `title` is link text and need not match the post's own
+   *  headline, matching the convention in free-tools.ts. */
+  relatedPosts?: { slug: string; title: string }[];
 }
 
 export interface SimpleFeature {
@@ -63,6 +132,95 @@ export const CORE_FEATURES: ProductFeature[] = [
     ],
     icon: Video,
     gradient: "from-purple-500 to-indigo-500",
+    seoTitle: "Train AI on Your YouTube Channel | Creator AI Studio",
+    seoDescription:
+      "Train AI on your YouTube channel in minutes. AI Studio learns your tone, pacing and vocabulary from your own videos, then writes everything in your voice.",
+    focusKeyword: "train ai on your youtube channel",
+    keywords: [
+      "ai trained on your own videos",
+      "youtube voice profile ai",
+      "ai that sounds like you",
+      "personalised ai for youtube creators",
+      "ai writing in your own voice",
+    ],
+    h1: "Train AI on Your YouTube Channel",
+    answerSummary:
+      "AI Studio trains Creator AI on your YouTube channel so everything it writes sounds like you rather than a generic model. You connect your channel, pick three to five videos you are happy with, and the AI studies your tone, vocabulary, pacing and structure. That trained voice profile then powers scripts, ideas, story outlines and dubbing across the rest of the product.",
+    steps: [
+      {
+        title: "Connect your channel",
+        description:
+          "One click links your YouTube account. The connection is read-only: Creator AI reads your public video data and the uploads you pick, and never posts on your behalf.",
+      },
+      {
+        title: "Pick three to five videos",
+        description:
+          "Choose uploads that sound the way you want to sound. Your best-performing video is not always your most characteristic one, and the AI learns from character.",
+      },
+      {
+        title: "Generate in your own voice",
+        description:
+          "Training runs in the background. After it finishes, every script, idea and outline is written through your voice profile instead of a default model tone.",
+      },
+    ],
+    sections: [
+      {
+        heading: "Why generic AI writes scripts that sound like nobody",
+        body: [
+          "Ask a general-purpose model for a YouTube script and you get the average of every script on the internet. It is competent, it is structurally fine, and it sounds like no particular person. Viewers notice inside about fifteen seconds, which is exactly the window where they decide whether to stay.",
+          "The problem is not the model's writing ability, it is that a prompt is a very thin description of a voice. Tell a model to be *casual and funny* and it produces a stranger's idea of casual and funny. What it cannot do from a prompt is reproduce the specific way you open a video, the phrases you overuse, or the pacing you have settled into after two hundred uploads.",
+          "**Training on your own videos closes that gap by giving the model examples instead of adjectives.** Your uploads already contain everything a description leaves out.",
+        ],
+      },
+      {
+        heading: "What AI Studio actually learns from your videos",
+        body: [
+          "**Vocabulary and phrasing.** The words you reach for, the ones you avoid, and the transitions you say out loud rather than the ones that only exist in writing.",
+          "**Pacing and structure.** How long you spend on a hook, whether you tease the payoff or deliver it, where you place a recap. This is the part that carries retention, and it is the part a prompt cannot describe.",
+          "**Tone under pressure.** How you handle a sponsor read, a correction, or a section you personally find boring. A voice profile built only from your best moments does not survive a real script.",
+        ],
+      },
+      {
+        heading: "Retraining, and when to train AI on your YouTube channel again",
+        body: [
+          "Channels drift. The way you presented two years ago is not the way you present now, and a voice profile pinned to old uploads slowly stops matching. Retraining on a fresher set of videos takes the same few minutes as the first run.",
+          "It is also the fastest fix when output feels slightly off. Nine times out of ten the problem is the training set rather than the prompt: a profile built from three unusually formal videos keeps producing unusually formal scripts no matter what you type into the brief.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "How many videos do I need to train the AI?",
+        answer:
+          "Three to five is enough. More videos do not linearly improve the profile, and a large set of inconsistent uploads produces a blurrier voice than a small set of characteristic ones.",
+      },
+      {
+        question: "Does Creator AI get permission to post to my channel?",
+        answer:
+          "No. The connection is read-only. Creator AI reads your public video data and the uploads you select for training, and it never publishes, edits or comments on your behalf.",
+      },
+      {
+        question: "What if my channel is new and I only have a few videos?",
+        answer:
+          "You can train on as little as one video, though the profile is thinner. Creators starting out often train on whichever videos sound closest to how they want to sound, then retrain once they have a real back catalogue.",
+      },
+      {
+        question: "Can I retrain the AI later?",
+        answer:
+          "Yes, as often as you like. Retraining replaces the existing voice profile, and everything generated afterwards uses the new one.",
+      },
+    ],
+    relatedFeatures: ["scripts", "ideation"],
+    relatedPosts: [
+      {
+        slug: "ai-script-tool-that-learns-your-voice-from-your-videos",
+        title: "Which AI Script Tools Actually Train on Your Videos",
+      },
+      {
+        slug: "creator-ai-vs-chatgpt-for-youtube-creators",
+        title: "Creator AI vs ChatGPT: Why Generic AI Falls Short for YouTube",
+      },
+    ],
   },
   {
     id: "scripts",
@@ -80,6 +238,95 @@ export const CORE_FEATURES: ProductFeature[] = [
     ],
     icon: PenTool,
     gradient: "from-pink-500 to-rose-500",
+    seoTitle: "AI Script Writing for YouTube, in Your Voice | Creator AI",
+    seoDescription:
+      "AI script writing for YouTube that sounds like you. Get a full script with a hook, real transitions and a closing CTA, trained on your own channel.",
+    focusKeyword: "ai script writing for youtube",
+    keywords: [
+      "ai youtube script writer",
+      "write youtube scripts with ai",
+      "youtube script ai in your own voice",
+      "ai scriptwriting tool for creators",
+      "generate a youtube script from a prompt",
+    ],
+    h1: "AI Script Writing for YouTube, in Your Own Voice",
+    answerSummary:
+      "Creator AI turns a one-line brief into a complete YouTube script written through your trained voice profile. You get a hook built for the first fifteen seconds, sections that flow rather than restart, and a closing call to action, in the language and runtime you choose. Because the model is trained on your uploads, the draft starts close to your voice instead of needing to be rewritten into it.",
+    steps: [
+      {
+        title: "Describe the video",
+        description:
+          "One sentence is enough. Add references, links or a file when the video depends on specific facts, and the script uses them instead of inventing them.",
+      },
+      {
+        title: "Set tone, language and length",
+        description:
+          "Runtime drives structure more than any other input. A six-minute script and a sixteen-minute script are different shapes, not the same script padded out.",
+      },
+      {
+        title: "Generate, then edit",
+        description:
+          "You get a full draft with hook, body and CTA. Storytelling mode and timestamps are toggles, so one brief can produce a narrative cut or a segmented tutorial.",
+      },
+    ],
+    sections: [
+      {
+        heading: "Why a script is not just copy",
+        body: [
+          "Written copy is read at the reader's pace, on a page they can scan and re-read. A script is heard once, in order, by someone who can leave at any moment. Every structural decision follows from that, and it is why general-purpose writing tools produce scripts that read well and perform badly.",
+          "A YouTube script has to earn each next thirty seconds. That means open loops that actually close, transitions that carry momentum instead of announcing a new topic, and a hook that promises something specific enough to be worth waiting for. **Those are retention mechanics, not style choices.**",
+        ],
+      },
+      {
+        heading: "What AI script writing for YouTube actually produces",
+        body: [
+          "**A hook written for the first fifteen seconds.** Not a summary of the video, a reason to stay for it.",
+          "**A body with real transitions.** Sections that hand off to each other, rather than eight paragraphs that each start from a standstill.",
+          "**A closing CTA in your voice.** The part most creators improvise and most script templates leave blank.",
+          "**Timestamps on request**, so the description is half written by the time you finish filming.",
+        ],
+      },
+      {
+        heading: "Where the free generator ends and this begins",
+        body: [
+          "The [free YouTube script generator](/tools/free-youtube-script-generator) writes from your prompt alone, with no account, and the output is yours to use. It is genuinely useful for a one-off.",
+          "The difference here is the voice profile. A trained account writes through [AI Studio](/features/ai-studio), so the draft arrives already sounding like your channel instead of needing a pass to make it sound like anyone at all. Across a weekly upload schedule, that pass is the actual cost.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "Can I write scripts in a language other than English?",
+        answer:
+          "Yes. Pick the output language before generating. The voice profile still applies, so the script keeps your structure and pacing in the target language.",
+      },
+      {
+        question: "How long can a generated script be?",
+        answer:
+          "Set a target runtime and the script is structured for it. Longer runtimes change the shape of the script, adding sections and recaps rather than stretching one outline.",
+      },
+      {
+        question: "Can I give the AI source material to work from?",
+        answer:
+          "Yes. Add links, pasted references or uploaded files as context and the script draws on them, which is how you keep a factual video factual.",
+      },
+      {
+        question: "Do I have to train the AI before writing scripts?",
+        answer:
+          "No, but it is the difference between a good generic script and a draft in your voice. Untrained accounts get the same structure with a default tone.",
+      },
+    ],
+    relatedFeatures: ["ai-studio", "story-builder"],
+    relatedPosts: [
+      {
+        slug: "youtube-scripts-that-keep-viewers-watching",
+        title: "How to Write YouTube Scripts That Keep Viewers Watching",
+      },
+      {
+        slug: "how-to-write-youtube-hooks-that-stop-the-scroll",
+        title: "How to Write YouTube Hooks That Stop the Scroll",
+      },
+    ],
   },
   {
     id: "ideation",
@@ -97,6 +344,93 @@ export const CORE_FEATURES: ProductFeature[] = [
     ],
     icon: Lightbulb,
     gradient: "from-amber-500 to-orange-500",
+    seoTitle: "AI Video Ideas for YouTube, Scored by Opportunity",
+    seoDescription:
+      "AI video ideas for YouTube, matched to your niche and scored for opportunity. See what is trending, where the gaps are, and which idea is worth filming.",
+    focusKeyword: "ai video ideas for youtube",
+    keywords: [
+      "ai youtube video idea tool",
+      "youtube content ideas ai",
+      "video ideas for my niche",
+      "youtube idea opportunity score",
+      "ai trend analysis for youtube",
+    ],
+    h1: "AI Video Ideas for YouTube, Scored Before You Film",
+    answerSummary:
+      "Creator AI generates video ideas for your niche and scores each one for opportunity instead of handing you a list of titles. It looks at what is currently working, finds the gaps your channel could fill, and returns every idea with a trend snapshot attached. You can run it fully automatic across your niche, or point it at a specific topic you already want to cover.",
+    steps: [
+      {
+        title: "Pick auto mode or a topic",
+        description:
+          "Auto mode reads your channel and niche and proposes ideas unprompted. Topic mode narrows the search to something you already have in mind.",
+      },
+      {
+        title: "Generate one to five ideas",
+        description:
+          "Each idea comes back with an angle, a trend snapshot and an opportunity score, so the shortlist is comparable rather than a wall of titles.",
+      },
+      {
+        title: "Send it straight to a story or a script",
+        description:
+          "An idea you like can be pushed into Story Builder or into a script, so the concept does not have to be retyped to be used.",
+      },
+    ],
+    sections: [
+      {
+        heading: "Why a list of titles is the wrong output",
+        body: [
+          "Most idea tools optimise for volume. Twenty titles feels generous until you try to film one and realise you still have to work out the angle, the opening, and whether anybody is actually looking for it. The list was never the hard part.",
+          "The hard part is knowing which idea is worth a weekend of your time. That is a judgement about competition, timing and fit with your channel, and it is precisely the judgement a bare list refuses to make.",
+        ],
+      },
+      {
+        heading: "What an opportunity score is actually measuring",
+        body: [
+          "The score weighs how much demand a topic currently has against how well it is already served. A saturated topic with strong existing coverage scores low even when it is popular, because popularity you cannot rank against is not an opportunity.",
+          "**It is designed to be able to tell you no.** A tool that scores every idea in the nineties is flattering you rather than helping you, and it makes the score worthless as a filter.",
+        ],
+      },
+      {
+        heading: "AI video ideas for YouTube that fit your channel, not the average one",
+        body: [
+          "Trend data on its own produces ideas for a generic creator in your niche. Combined with a trained voice profile and your upload history, the same trend produces ideas you could actually make: the angle assumes your format, your depth, and the audience you already have.",
+          "There is a free version of this at the [YouTube video ideas generator](/tools/free-youtube-video-ideas-generator), which works from a niche alone and needs no account.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "How is this different from asking ChatGPT for video ideas?",
+        answer:
+          "A general model generates plausible ideas from its training data, with no view of what is currently working or what your channel has already covered. The scoring and the trend snapshot are the parts a chat prompt cannot produce.",
+      },
+      {
+        question: "Can I focus the ideas on a specific topic?",
+        answer:
+          "Yes. Auto mode proposes ideas across your niche, and topic mode takes a subject you name and generates angles within it.",
+      },
+      {
+        question: "How many ideas can I generate at once?",
+        answer:
+          "One to five per session. The cap is deliberate: five scored ideas you will compare beats fifty you will not read.",
+      },
+      {
+        question: "Do the ideas come with anything I can film from?",
+        answer:
+          "Each idea carries an angle, a hook direction and talking points, and can be sent into Story Builder or a script without being retyped.",
+      },
+    ],
+    relatedFeatures: ["story-builder", "scripts"],
+    relatedPosts: [
+      {
+        slug: "how-to-find-trending-youtube-video-topics-2026",
+        title: "How to Find Trending YouTube Video Topics",
+      },
+      {
+        slug: "youtube-video-ideation-system-for-youtube-creators-2026",
+        title: "The YouTube Video Ideation System That Beats Guessing",
+      },
+    ],
   },
   {
     id: "story-builder",
@@ -114,6 +448,93 @@ export const CORE_FEATURES: ProductFeature[] = [
     ],
     icon: Clapperboard,
     gradient: "from-cyan-500 to-blue-500",
+    seoTitle: "YouTube Video Outline Planner With Retention Scoring",
+    seoDescription:
+      "A YouTube video outline planner that maps hooks, escalation and payoff, then scores the structure for retention before you spend a day filming it.",
+    focusKeyword: "youtube video outline planner",
+    keywords: [
+      "youtube video structure planner",
+      "plan a youtube video before filming",
+      "retention score for video outlines",
+      "video blueprint tool for creators",
+      "hook and payoff planning youtube",
+    ],
+    h1: "A YouTube Video Outline Planner That Scores Retention First",
+    answerSummary:
+      "Story Builder is a YouTube video outline planner that maps a video's structure before you write a word of script. You set the audience, content type, tone and runtime, and it returns a blueprint with a hook, escalation points and a payoff, plus a retention score predicting whether that shape will hold attention. Weak structure is cheap to fix at the outline stage and expensive to fix after filming.",
+    steps: [
+      {
+        title: "Define the video",
+        description:
+          "Audience, content type, tone and target runtime. These four inputs change the shape of the outline more than the topic itself does.",
+      },
+      {
+        title: "Get a structured blueprint",
+        description:
+          "Hook, escalation points, payoff and the beats between them, laid out in order rather than as a list of things you ought to mention.",
+      },
+      {
+        title: "Read the retention score, then adjust",
+        description:
+          "The score flags where attention is likely to drop. Reordering beats now costs minutes; finding the same problem in the edit costs the shoot.",
+      },
+    ],
+    sections: [
+      {
+        heading: "Why a YouTube video outline planner beats writing the script first",
+        body: [
+          "Most videos that lose viewers do not lose them to bad writing. They lose them to a shape that was never going to work: a payoff placed too late, three escalations of the same size, or a middle section that exists because it was on the list.",
+          "Writing the script first hides this. Prose is persuasive, and a well-written scene reads fine inside a structure that cannot hold attention. Planning the shape first makes the problem visible while it is still free to fix.",
+        ],
+      },
+      {
+        heading: "What the retention score is, and what it is not",
+        body: [
+          "The score is a prediction about structure, based on where attention typically drops in videos of that type and length. It is not a promise, and it knows nothing about how good your delivery is.",
+          "**Used as a comparator it is genuinely useful:** two outlines for the same video, scored, tells you which shape to film. Used as a number to maximise, it will push you toward formulaic videos, which is not what it is for.",
+        ],
+      },
+      {
+        heading: "From outline to script without retyping",
+        body: [
+          "A finished blueprint feeds straight into script writing, so the structure you approved is the structure the script follows. Ideas from [Video Ideas](/features/ideation) can be linked in at the top of the same flow.",
+          "The [free story structure generator](/tools/free-youtube-story-structure-generator) runs the same idea without an account, at a shorter length and without your voice profile attached.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "What is the retention score based on?",
+        answer:
+          "Where attention typically drops in videos of the same type and runtime, applied to the shape of your outline. It scores structure, not delivery or production quality.",
+      },
+      {
+        question: "Do I have to use Story Builder before writing a script?",
+        answer:
+          "No. It exists for videos where structure is the risk, which is most long-form and narrative content. A short tutorial usually does not need it.",
+      },
+      {
+        question: "Can I edit the blueprint it gives me?",
+        answer:
+          "Yes. The outline is a starting structure, not a locked template, and rescoring after an edit shows whether the change actually helped.",
+      },
+      {
+        question: "Can I bring in an idea I already generated?",
+        answer:
+          "Yes. Ideas from Video Ideas link directly into a story, so the angle and hook carry over instead of being rewritten.",
+      },
+    ],
+    relatedFeatures: ["ideation", "scripts"],
+    relatedPosts: [
+      {
+        slug: "youtube-video-story-structure-for-retention-2026",
+        title: "Story Structure 101: Plan Videos That People Actually Finish",
+      },
+      {
+        slug: "improve-youtube-audience-retention-watch-time",
+        title: "How to Improve YouTube Audience Retention and Watch Time",
+      },
+    ],
   },
   {
     id: "thumbnails",
@@ -131,6 +552,93 @@ export const CORE_FEATURES: ProductFeature[] = [
     ],
     icon: ImageIcon,
     gradient: "from-emerald-500 to-green-500",
+    seoTitle: "AI Thumbnail Generator for YouTube | Creator AI",
+    seoDescription:
+      "An AI thumbnail generator for YouTube that works from a prompt, a frame of your video or your own references, and keeps your channel style consistent.",
+    focusKeyword: "ai thumbnail generator for youtube",
+    keywords: [
+      "generate youtube thumbnails with ai",
+      "thumbnail from video frame",
+      "consistent thumbnail style youtube",
+      "ai thumbnail from reference images",
+      "youtube thumbnail aspect ratios",
+    ],
+    h1: "An AI Thumbnail Generator for YouTube That Keeps Your Style",
+    answerSummary:
+      "Creator AI generates YouTube thumbnails from a text description, a frame pulled out of your own video, or reference images you upload. It produces finished images at the aspect ratios YouTube actually uses, and it can work from your existing thumbnails so a new one looks like it belongs on your channel. The point is a usable thumbnail in a minute, not a design brief.",
+    steps: [
+      {
+        title: "Describe it, or start from a frame",
+        description:
+          "A text description is enough to get going. Pulling a frame out of the video itself is usually better, because the face and the moment are already right.",
+      },
+      {
+        title: "Add reference images for style",
+        description:
+          "Upload thumbnails you have used before and the generator matches the treatment, which is what keeps a channel visually consistent over time.",
+      },
+      {
+        title: "Generate and pick an aspect ratio",
+        description:
+          "Output arrives at the ratios you need, ready to upload rather than ready to crop.",
+      },
+    ],
+    sections: [
+      {
+        heading: "Why an AI thumbnail generator for YouTube should copy your own style",
+        body: [
+          "A thumbnail's first job is not to be striking. It is to be recognisable in a feed where your video sits next to eleven others, one of which is also yours. Channels with a visual signature get clicked by people who already know them, and that is most of your early traffic.",
+          "This is why generating from references matters more than generating from a prompt. **A prompt produces a good image; references produce your image.**",
+        ],
+      },
+      {
+        heading: "Working from a frame of the real video",
+        body: [
+          "The strongest thumbnails usually come out of the footage. The expression is real, the lighting matches the video, and the viewer is not promised a moment that never actually happens on screen.",
+          "Pulling a frame and generating around it keeps that authenticity while fixing what a raw frame gets wrong: the crop, the contrast, and the empty third where text has to go.",
+        ],
+      },
+      {
+        heading: "What this does not try to be",
+        body: [
+          "This is not a full design editor and does not pretend to be one. If you already have a thumbnail process in Canva or Photoshop that works, the sensible use here is generating the base image and finishing it where you already work.",
+          "For creators without that process, it removes the step that most often delays an upload by a day.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "What size are the generated thumbnails?",
+        answer:
+          "They come out at YouTube's standard 16:9 proportions, with other aspect ratios available for Shorts and for use off the platform.",
+      },
+      {
+        question: "Can I use my own photos or previous thumbnails?",
+        answer:
+          "Yes, and it is the recommended path. Uploading references is what makes a new thumbnail look like it belongs to your channel rather than to a model.",
+      },
+      {
+        question: "Can I pull the image from the video itself?",
+        answer:
+          "Yes. Upload the video, choose a frame, and generate around it.",
+      },
+      {
+        question: "Do I need design skills to use it?",
+        answer:
+          "No. The output is a finished image. Creators who already have a design workflow tend to use it for the base and finish elsewhere.",
+      },
+    ],
+    relatedFeatures: ["subtitles", "video-generation"],
+    relatedPosts: [
+      {
+        slug: "youtube-thumbnail-mistakes-killing-your-ctr-2026",
+        title: "5 Thumbnail Mistakes Killing Your CTR",
+      },
+      {
+        slug: "best-ai-thumbnail-maker-tools-that-boost-youtube-ctr-2026",
+        title: "17 AI Thumbnail Tools Tested on Real Uploads",
+      },
+    ],
   },
   {
     id: "subtitles",
@@ -148,6 +656,93 @@ export const CORE_FEATURES: ProductFeature[] = [
     ],
     icon: MessageSquare,
     gradient: "from-violet-500 to-purple-500",
+    seoTitle: "Automatic Video Subtitle Generator With SRT and VTT Export",
+    seoDescription:
+      "An automatic video subtitle generator with an inline editor and SRT or VTT export. Upload a video, get timed captions, fix what matters, then publish.",
+    focusKeyword: "automatic video subtitle generator",
+    keywords: [
+      "auto generate subtitles for video",
+      "srt and vtt export tool",
+      "edit subtitles against the video",
+      "add captions to youtube videos",
+      "video transcription and timing",
+    ],
+    h1: "An Automatic Video Subtitle Generator You Can Actually Edit",
+    answerSummary:
+      "Creator AI transcribes an uploaded video into timed subtitles and gives you an editor with the player beside the text, so corrections happen in context. Once the captions are right you export them as SRT or VTT and upload them with the video. That editing step is the point: automatic transcription is fast everywhere, and it is the names, jargon and product terms it gets wrong that cost you.",
+    steps: [
+      {
+        title: "Upload the video",
+        description:
+          "Transcription and timing happen together, so the first draft is already synced rather than a wall of text you have to align by hand.",
+      },
+      {
+        title: "Fix it against the player",
+        description:
+          "The editor sits beside the video. You correct a line while hearing it, which is the only reliable way to catch a wrong word that is still a real word.",
+      },
+      {
+        title: "Style it and export",
+        description:
+          "Export as SRT or VTT. Both are plain text and both upload directly to YouTube.",
+      },
+    ],
+    sections: [
+      {
+        heading: "Where every automatic video subtitle generator fails",
+        body: [
+          "Automatic transcription is accurate on ordinary speech and unreliable on the words that carry your video: names, technical terms, product names, and anything said quickly or over music. Those are also the words a viewer notices being wrong.",
+          "The accuracy figure a tool advertises is an average across ordinary speech. **It tells you very little about the twenty words in your video that actually have to be right**, which is why an editing pass is not optional.",
+        ],
+      },
+      {
+        heading: "Subtitles are a watch-time feature, not a checkbox",
+        body: [
+          "Captions are an accessibility requirement, and that alone justifies them. They are also, on YouTube specifically, a retention feature: a large share of viewing happens muted, in public, or in a second language.",
+          "A video without captions is unavailable to those viewers in the first few seconds, which is the same window everything else on this page is about.",
+        ],
+      },
+      {
+        heading: "SRT or VTT, and when the difference matters",
+        body: [
+          "SRT is the universal format and the right default for YouTube. VTT supports styling and positioning, which matters when captions have to avoid burned-in text or sit somewhere specific on screen.",
+          "Both export from the same editor, so the choice is about where the file is going rather than about redoing the work. [SRT vs VTT](/blog/srt-vs-vtt-subtitle-formats-explained-2026) covers where each one breaks.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "What formats can I export?",
+        answer:
+          "SRT and VTT. SRT is the safe default for YouTube; VTT is the one to pick when you need caption styling or positioning.",
+      },
+      {
+        question: "How accurate is the automatic transcription?",
+        answer:
+          "Accurate enough on ordinary speech that editing is a pass rather than a retype, and unreliable on names and jargon, which is exactly what the inline editor is for.",
+      },
+      {
+        question: "Can I edit the timings as well as the words?",
+        answer:
+          "Yes. Timing and text are both editable against the player, so a caption that lands late can be nudged rather than rewritten.",
+      },
+      {
+        question: "Do subtitles help with YouTube search?",
+        answer:
+          "Indirectly. The clearer win is watch time from muted and non-native viewers, which is a much larger share of the audience than most creators assume.",
+      },
+    ],
+    relatedFeatures: ["dubbing", "thumbnails"],
+    relatedPosts: [
+      {
+        slug: "how-subtitles-boost-youtube-views-and-watch-time",
+        title: "How Subtitles Increase YouTube Views and Watch Time",
+      },
+      {
+        slug: "accurate-ai-subtitle-generator-for-youtube-tested-2026",
+        title: "7 AI Subtitle Generators Tested on Real Accents",
+      },
+    ],
   },
   {
     id: "dubbing",
@@ -165,6 +760,93 @@ export const CORE_FEATURES: ProductFeature[] = [
     ],
     icon: Languages,
     gradient: "from-teal-500 to-emerald-500",
+    seoTitle: "Dub Videos in Your Own Voice With AI | Creator AI",
+    seoDescription:
+      "Dub videos in your own voice instead of a stock narrator. Creator AI clones your voice, translates the audio and times it against the original video.",
+    focusKeyword: "dub videos in your own voice",
+    keywords: [
+      "ai dubbing with voice cloning",
+      "translate youtube videos keeping your voice",
+      "dubbed audio track for youtube",
+      "multi language youtube channel",
+      "voice clone dubbing for creators",
+    ],
+    h1: "Dub Videos in Your Own Voice, Not a Stranger's",
+    answerSummary:
+      "Creator AI dubs a finished video into another language using a clone of your own voice, so the translated version still sounds like your channel. The translated audio is timed against the original video and downloads as a track you can attach to your upload. The alternative, on YouTube's own auto-dubbing and on most tools, is a competent stranger reading your script.",
+    steps: [
+      {
+        title: "Upload the finished video",
+        description:
+          "Dubbing runs on a finished cut rather than a script, so what gets translated is what viewers actually hear.",
+      },
+      {
+        title: "Pick the target language",
+        description:
+          "The AI translates and performs the audio in a clone of your voice rather than handing it to a stock narrator.",
+      },
+      {
+        title: "Download the dubbed track",
+        description:
+          "The audio comes back timed to the original video, ready to attach as an alternate track.",
+      },
+    ],
+    sections: [
+      {
+        heading: "Voice is most of what a subscriber subscribed to",
+        body: [
+          "A dubbed video in a generic synthesized voice reaches a new audience with the one thing your channel is built on removed. The information survives. The reason anyone chose you does not.",
+          "**This is the specific gap voice cloning closes.** YouTube's native auto-dubbing is free, wide, and reads your script in somebody else's voice. That is a reasonable trade for some channels and a bad one for any channel whose delivery is the product.",
+        ],
+      },
+      {
+        heading: "What dubbing costs, and when it is worth it",
+        body: [
+          "Dubbing is priced per minute of finished video, so the cost of testing a language is one video rather than a commitment. That is the sensible way to find out whether a market exists for your content before translating a back catalogue into it.",
+          "The videos worth dubbing first are usually evergreen. A tutorial that still pulls traffic two years on earns the translation back; a news reaction does not.",
+        ],
+      },
+      {
+        heading: "When to dub videos in your own voice, and where it fits",
+        body: [
+          "Dubbing is the last step. It runs on the finished video, after the script, the edit and usually the [subtitles](/features/subtitles) are done.",
+          "Captions and a dub answer different problems, though, and one is not a substitute for the other: captions serve viewers who cannot or will not use audio, and a dub serves viewers who would simply rather listen in their own language.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "Does it use my real voice or a synthetic one?",
+        answer:
+          "A clone of your voice, built from your own audio, so the dubbed track keeps your delivery instead of replacing it with a stock narrator.",
+      },
+      {
+        question: "How is this different from YouTube's free auto-dubbing?",
+        answer:
+          "YouTube's auto-dubbing is free and generic: it translates accurately into a synthesized voice you do not control. Voice cloning keeps the voice, which for most channels is the entire point of dubbing.",
+      },
+      {
+        question: "Is it legal to clone my own voice?",
+        answer:
+          "Yes. Cloning a voice you own, for your own content, is uncontroversial. Consent is what the law cares about here, and it is yours to give.",
+      },
+      {
+        question: "How is dubbing priced?",
+        answer:
+          "Per minute of finished video, which makes a single video a cheap way to test whether an audience exists in a language before committing to more.",
+      },
+    ],
+    relatedFeatures: ["subtitles", "ai-studio"],
+    relatedPosts: [
+      {
+        slug: "how-to-dub-youtube-videos-into-multiple-languages-ai",
+        title: "How to Dub YouTube Videos Into Multiple Languages With AI",
+      },
+      {
+        slug: "youtube-auto-dubbing-vs-ai-voice-cloning-explained",
+        title: "YouTube Auto-Dubbing vs AI Voice Cloning",
+      },
+    ],
   },
   {
     id: "video-generation",
@@ -182,6 +864,93 @@ export const CORE_FEATURES: ProductFeature[] = [
     ],
     icon: Film,
     gradient: "from-fuchsia-500 to-pink-500",
+    seoTitle: "AI Video Clip Generator for B-Roll and Openers",
+    seoDescription:
+      "An AI video clip generator that turns a prompt or a starting image into a short clip with audio, for B-roll, openers and testing a shot before filming.",
+    focusKeyword: "ai video clip generator",
+    keywords: [
+      "generate b-roll with ai",
+      "text to video clip for youtube",
+      "image to video generation",
+      "ai opener clips for videos",
+      "short ai video with audio",
+    ],
+    h1: "An AI Video Clip Generator for B-Roll and Openers",
+    answerSummary:
+      "Creator AI generates short video clips, with audio, from a text prompt or a starting image. The clips are meant to be used inside a real edit as B-roll, an opening shot, or a visual for something you cannot film, and they download ready to drop onto a timeline. It is also the cheapest way to see whether a shot you have in mind works before you build it.",
+    steps: [
+      {
+        title: "Write the shot, or start from an image",
+        description:
+          "Describe the clip you need. Starting from an image gives you far more control over framing and subject than a prompt alone does.",
+      },
+      {
+        title: "Generate with audio",
+        description:
+          "Audio is generated alongside the video, so the clip is usable without a separate sound pass.",
+      },
+      {
+        title: "Download and cut it in",
+        description:
+          "The clip downloads in a standard format and goes straight onto the timeline in whatever editor you already use.",
+      },
+    ],
+    sections: [
+      {
+        heading: "What an AI video clip generator is actually good for",
+        body: [
+          "Generated video is not a replacement for filming, and treating it as one produces videos that feel synthetic. Where it earns its place is the footage you were never going to film anyway: an establishing shot of a place you are not in, an abstract visual over a narration section, a three-second opener.",
+          "**This is the B-roll problem**, and it is the reason creators end up paying stock libraries for clips that look like everybody else's.",
+        ],
+      },
+      {
+        heading: "Starting from an image instead of a prompt",
+        body: [
+          "A prompt gives the model total freedom, which is why prompt-only clips often look impressive and fit nothing. Starting from an image pins down the subject, the framing and the palette, and asks the model only to handle motion.",
+          "For anything that has to match the rest of your video, image-to-video is the mode to reach for.",
+        ],
+      },
+      {
+        heading: "Testing an idea before committing to a shoot",
+        body: [
+          "A generated clip is a cheap storyboard that moves. If a shot in your head is going to cost half a day to set up, it is worth seeing an approximation of it first.",
+          "The same logic applies to openers, which get rewritten more often than any other part of a video.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "How long are the generated clips?",
+        answer:
+          "Short, in the range you would use for B-roll or an opener rather than a full scene. They are built to be cut into a video, not to be one.",
+      },
+      {
+        question: "Does the clip come with audio?",
+        answer:
+          "Yes. Audio is generated with the video, so the clip is usable without a separate sound pass.",
+      },
+      {
+        question: "Can I control the look of the clip?",
+        answer:
+          "Starting from an image gives you the most control: it fixes the subject and framing and leaves the model to handle motion. Prompt-only generation is freer and less predictable.",
+      },
+      {
+        question: "What can I do with the clips once they are generated?",
+        answer:
+          "Download and use them in your edit. They are ordinary video files and go into any editor.",
+      },
+    ],
+    relatedFeatures: ["thumbnails", "scripts"],
+    relatedPosts: [
+      {
+        slug: "best-ai-tools-for-faceless-youtube-channels-2026",
+        title: "10 Best AI Tools for Faceless YouTube Channels",
+      },
+      {
+        slug: "best-ai-tools-to-turn-long-videos-into-shorts-2026",
+        title: "9 Best AI Tools to Turn Long Videos Into YouTube Shorts",
+      },
+    ],
   },
 ]
 
@@ -211,3 +980,15 @@ export const EXTRA_FEATURES: SimpleFeature[] = [
     icon: Gift,
   },
 ]
+
+/**
+ * Lookup by slug for the /features/<slug> route. Mirrors getFreeTool in
+ * lib/free-tools.ts. Only CORE_FEATURES get pages: the COMING_SOON and EXTRA
+ * lists are SimpleFeature, carry no id and no page copy, and stay on the hub.
+ */
+export function getFeature(slug: string): ProductFeature | undefined {
+  return CORE_FEATURES.find((feature) => feature.id === slug);
+}
+
+/** Every slug with a detail page, for generateStaticParams and the sitemap. */
+export const FEATURE_SLUGS: string[] = CORE_FEATURES.map((feature) => feature.id);

--- a/packages/validations/src/schema/thumbnail.schema.ts
+++ b/packages/validations/src/schema/thumbnail.schema.ts
@@ -2,18 +2,40 @@ import { z } from 'zod';
 
 export const THUMBNAIL_RATIOS = ['16:9', '9:16', '1:1', '4:3'] as const;
 
+// The source a thumbnail request came from — a script, a story blueprint, or one
+// idea inside an ideation job. Shared by /generate and /surprise so both resolve
+// the same server-side content context.
+const ThumbnailSourceShape = {
+  scriptId: z.string().uuid().optional(),
+  storyBuilderId: z.string().uuid().optional(),
+  ideationId: z.string().uuid().optional(),
+  ideaIndex: z.coerce.number().int().min(0).optional(),
+};
+
 export const CreateThumbnailSchema = z.object({
   prompt: z
     .string()
     .min(3, 'Prompt must be at least 3 characters')
     .max(2000, 'Prompt must not exceed 2000 characters'),
+  context: z
+    .string()
+    .max(2000, 'Context must not exceed 2000 characters')
+    .optional()
+    .or(z.literal('')),
   ratio: z.enum(THUMBNAIL_RATIOS).default('16:9'),
   generateCount: z.coerce.number().int().min(1).max(5).default(3),
   videoLink: z.string().url('Invalid video URL').optional().or(z.literal('')),
   personalized: z.coerce.boolean().optional().default(true),
-  scriptId: z.string().uuid().optional(),
-  storyBuilderId: z.string().uuid().optional(),
+  ...ThumbnailSourceShape,
+});
+
+// "Surprise me" prompt generator — seeded by the source the creator came from
+// plus whatever they typed into Additional Context.
+export const SurpriseThumbnailPromptSchema = z.object({
+  context: z.string().max(2000).optional().or(z.literal('')),
+  ...ThumbnailSourceShape,
 });
 
 export type ThumbnailRatio = (typeof THUMBNAIL_RATIOS)[number];
 export type CreateThumbnailInput = z.infer<typeof CreateThumbnailSchema>;
+export type SurpriseThumbnailPromptInput = z.infer<typeof SurpriseThumbnailPromptSchema>;

--- a/packages/workers/src/processor/thumbnail.processor.ts
+++ b/packages/workers/src/processor/thumbnail.processor.ts
@@ -24,6 +24,10 @@ interface ThumbnailJobData {
   faceImageUrl?: string;
   videoLink?: string;
   personalized: boolean;
+  /** Resolved server-side from the script / blueprint / idea the request came from. */
+  contentContext?: string;
+  /** Whatever the creator typed into "Additional Context". */
+  userContext?: string;
 }
 
 interface StyleData {
@@ -53,6 +57,7 @@ export class ThumbnailProcessor extends WorkerHost {
     const {
       userId, thumbnailJobId, bullJobId, prompt, ratio,
       generateCount, referenceImageUrl, faceImageUrl, videoLink, personalized,
+      contentContext, userContext,
     } = job.data;
 
     await job.updateProgress(0);
@@ -89,6 +94,13 @@ export class ThumbnailProcessor extends WorkerHost {
         ? `\nThis thumbnail is for a YouTube video: ${videoLink}. Reflect the video's themes.`
         : '';
 
+      // What the video is actually about — from the linked script/blueprint/idea and
+      // from the creator's own notes. Without it the model only sees the raw prompt.
+      const briefContext = [
+        contentContext && `What the video is about:\n${contentContext}`,
+        userContext && `Creator notes:\n${userContext}`,
+      ].filter(Boolean).join('\n\n');
+
       const count = Math.min(generateCount || 3, 4);
       await job.log(`Generating ${count} thumbnail variations in parallel...`);
 
@@ -108,7 +120,7 @@ Optimized for YouTube click-through rate.
 Bold vibrant colors, dramatic composition, high contrast, cinematic lighting.
 Variation directive: ${hint}
 ${videoContext}
-
+${briefContext ? `\n${briefContext}\n` : ''}
 ${prompt}`;
 
         const parts: any[] = [{ text: textPrompt }, ...contextParts];


### PR DESCRIPTION
## Why

Two things on the thumbnail page weren't doing what they looked like they were doing.

**The presets were the same three strings for everyone.** "Tech Tutorial", "Travel Vlog", "Cooking / Food" — hardcoded, ignoring the channel style we already train on, with a `@todo` on top saying they should come from the DB one day.

**The "Create Thumbnail" buttons dropped a raw title into the prompt field.** `?prompt=How%20I%20Ship%20Faster` is a video title, not a description of an image. Scripts, blueprints and ideas all did this.

## What changed

### Surprise me replaces the presets

`POST /api/v1/thumbnail/surprise` mirrors the video-generation endpoint: reads `user_style`, resolves whichever source the request came from, and returns one thumbnail-shaped prompt — subject, composition, lighting, and a short text overlay. Ungated, for the same reason video-gen's is: it's cheap, and it lets a locked user see the feature work before the paywall on Generate.

The button sits on the prompt label and types the result in, same interaction as video generation.

### The entry points pass identity, not a title

| From | Before | After |
|---|---|---|
| Script detail | `?scriptId&prompt=title` | `?scriptId&title=` |
| Story blueprint | `?storyBuilderId&prompt=topic` | `?storyBuilderId&title=` |
| Ideation card | `?prompt=title` only | `?ideationId&ideaIndex&title=` |

The ideation card now matches the Script and Story Builder buttons sitting right next to it, which already passed `ideationId` + `ideaIndex`.

Server-side, `resolveSourceContext` turns each into real content: script title + body, blueprint topic + hook + suggested visual + biggest insight, or the indexed idea's angle, hook and format. Shared by `/generate` and `/surprise` so both see the same thing. Landing from a feature with an empty prompt drafts one automatically, so the form arrives filled. `?prompt=` still works for existing links.

### Two dropped inputs, now wired

- The **Additional Context** textarea was collected in the hook and never sent anywhere.
- The worker never declared `contentContext`, so the script and blueprint context `createJob` had been queuing for it went nowhere.

Both now reach the image prompt. Expect noticeably different output for source-linked jobs — that's the point, but it is a behaviour change to the generated images.

### Incidental

The letter-by-letter reveal was about to be a second copy, so it moved to `useTypewriter` and video generation calls it.

## Testing

`thumbnail.service.spec.ts` covers the three source branches, the no-source fallback, and empty model output — asserting on what the model actually gets briefed with. Full API suite (145) green; web and api lint and type-checks clean.

Not covered by tests: the auto-draft on landing and the button itself, both worth a click through from a script, a blueprint and an idea card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
